### PR TITLE
Update Emulator Support Page with core-specific issues

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -4,42 +4,44 @@
 
 ### 3DO Interactive Multiplayer
 
-- ✅ libretro core: **Opera**<br>
+- ✅ libretro core: **Opera**
   - Some issues depending on BIOS
 
 ### Amiga
 
 - ❓ libretro core: **FS-UAE**
-- ❌ libretro core: **P-UAE**<br>
-  - Needs memory map to see exposed memory<br>
-  - Locks disk files so they can't be opened for hashing<br>
-  - Hard disk support?<br>
+- ❌ libretro core: **P-UAE**
+  - Needs memory map to see exposed memory
+  - Locks disk files so they can't be opened for hashing
+  - Hard disk support?
 - ❓ libretro core: **PUAE 2021**
 - ❓ libretro core: **UAE4ARM**
 
 ### Amstrad CPC
 
-- ✅ libretro core: **Caprice32**<br>
+- ✅ libretro core: **Caprice32**
   - Core does not currently support writing to disk, which may affect hashing when implemented
 - ❌ libretro core: **CrocoDS**
 
 ### Apple II
 
 - ✅ Standalone emulator: **[RAppleWin](https://retroachievements.org/download.php#rapplewin)**
-- ⌛ BizHawk core: **Virtu**<br>
-  - Testing<br>
-  - 4 Jun 2023 - woz files are not supported<br>
-  - 4 Jun 2023 - joystick not supported. keyboard has to be manually mapped.<br>
+- ⌛ BizHawk core: **Virtu**
+  - Testing
+  - 4 Jun 2023 - woz files are not supported
+  - 4 Jun 2023 - joystick not supported. keyboard has to be manually mapped.
   - 4 Jun 2023 - have to manually create and load a multi-disk bundle for games with multiple disks. disks are generically labelled by index only.
 
 ### Arcade
 
-- ✅ libretro core: **FinalBurn Neo**<br>
+- ✅ libretro core: **FinalBurn Neo**
   - Some boards may not be fully exposed
-- ✅ libretro core: **flycast**<br>
+- ✅ libretro core: **flycast**
   - Used for Atomiswave, NAOMI, and NAOMI2
-- ❌ libretro core: **FB Alpha**<br>
+- ❌ libretro core: **FB Alpha**
   - Deprecated
+- ❌ libretro core: **MAME**
+- ❌ BizHawk core: **MAME**
 
 ### Arcadia 2001
 
@@ -54,14 +56,15 @@
 - ✅ libretro core: **Stella**
 - ❓ libretro core: **Stella 2014**
 - ✅ BizHawk core: **Atari2600Hawk**
+  - Achievements that require emulator resets do not work - if you see one, please open a ticket so the achievement can be fixed.
 
 #### Atari 5200
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **atari800**<br>
-  - Appears to work fine, but the core is a bit of a headache to use.<br>
-    - The BIOS has to be configured within the core (F1 > Emulator Configuration > System ROM settings)<br>
-    - Couldn't figure out controls - does the joystick need to be configured within the core too?<br>
+- ❌ libretro core: **atari800**
+  - Appears to work fine, but the core is a bit of a headache to use.
+    - The BIOS has to be configured within the core (F1 > Emulator Configuration > System ROM settings)
+    - Couldn't figure out controls - does the joystick need to be configured within the core too?
     - Allows loading arbitrary files from the internal menu, which bypasses hashing
 - ❌ libretro core: **a5200**
   - Does not expose memory
@@ -73,8 +76,8 @@
 
 #### Atari Jaguar
 
-- ✅ libretro core: **Virtual Jaguar**<br>
-  - No save state support<br>
+- ✅ libretro core: **Virtual Jaguar**
+  - No save state support
   - [Many issues with emulation](https://github.com/libretro/virtualjaguar-libretro/issues/38)
 - ✅ BizHawk core: **Virtual Jaguar**
 
@@ -84,7 +87,7 @@
 
 #### Atari Lynx
 
-- ✅ libretro core: **Handy**<br>
+- ✅ libretro core: **Handy**
   - Most recommended
 - ✅ libretro core: **Beetle Lynx**
 - ✅ BizHawk core: **Handy** (Mednafen's fork)
@@ -92,7 +95,7 @@
 #### Atari ST
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **Hatari**<br>
+- ❌ libretro core: **Hatari**
   - Memory not exposed
 
 #### Cassette Vision
@@ -103,8 +106,8 @@
 
 - ❌ _Not supported_ - needs console ID, hashing method and memory map
 - ❌ libretro core: **Emux CHIP-8**
-- ❌ libretro core: **JAXE**<br>
-  - 16 Apr 22 - Seems ready when we are<br>
+- ❌ libretro core: **JAXE**
+  - 16 Apr 22 - Seems ready when we are
   - May need settings blacklist to prevent lowering speed
 
 #### Commodore 128
@@ -114,10 +117,10 @@
 
 #### Commodore 64
 
-- ❌ libretro core: **vice_x64**<br>
-  - NOTE: Joystick is in port 2 by default. Use JOY button on virtual keyboard (select) to switch it to port 1.<br>
+- ❌ libretro core: **vice_x64**
+  - NOTE: Joystick is in port 2 by default. Use JOY button on virtual keyboard (select) to switch it to port 1.
   - 1 May 2022 - Reset does not autorun game
-- ⌛ BizHawk core: C64Hawk<br>
+- ⌛ BizHawk core: C64Hawk
   - Testing
 - ❓ libretro core: **Frodo**
 
@@ -160,13 +163,13 @@
 #### Game & Watch
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **gw**<br>
+- ❌ libretro core: **gw**
   - Does not expose memory
 
 #### Game Boy
 
 - ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
-- ✅ libretro core: **Gambatte**<br>
+- ✅ libretro core: **Gambatte**
   - Most recommended
 - ✅ libretro core: **Gearboy**
 - ✅ libretro core: **mGBA**
@@ -179,11 +182,11 @@
 
 #### Game Boy Color
 
-- ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**<br>
-- ✅ Standalone emulator: **[Pizza Boy GBC](https://play.google.com/store/apps/details?id=it.dbtecno.pizzaboy)**<br>
-  - Android devices only<br>
+- ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
+- ✅ Standalone emulator: **[Pizza Boy GBC](https://play.google.com/store/apps/details?id=it.dbtecno.pizzaboy)**
+  - Android devices only
   - Does not support RAIntegration at this time, so achievement developers are unable to troubleshoot potential issues.
-- ✅ libretro core: **Gambatte**<br>
+- ✅ libretro core: **Gambatte**
   - Most recommended
 - ✅ libretro core: **Gearboy**
 - ✅ libretro core: **mGBA**
@@ -199,13 +202,13 @@
 #### Game Boy Advance
 
 - ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
-- ✅ Standalone emulator: **[Pizza Boy GBA](https://play.google.com/store/apps/details?id=it.dbtecno.pizzaboygba)**<br>
-  - Android devices only<br>
+- ✅ Standalone emulator: **[Pizza Boy GBA](https://play.google.com/store/apps/details?id=it.dbtecno.pizzaboygba)**
+  - Android devices only
   - Does not support RAIntegration at this time, so achievement developers are unable to troubleshoot potential issues.
 - ✅ libretro core: **VBA-M**
 - ✅ libretro core: **Beetle GBA**
 - ✅ libretro core: **VBA Next**
-- ✅ libretro core: **mGBA**<br>
+- ✅ libretro core: **mGBA**
   - Most recommended
 - ✅ BizHawk core: **mGBA**
 - ❓ libretro core: **gpSP**
@@ -214,9 +217,9 @@
 
 #### GameCube
 
-- ⌛ Standalone emulator: **Dolphin**<br>
+- ⌛ Standalone emulator: **Dolphin**
   - Testing
-- ⌛ libretro core: **Dolphin**<br>
+- ⌛ libretro core: **Dolphin**
   - Testing
 
 #### Game Gear
@@ -227,17 +230,17 @@
 
 #### Genesis / Mega Drive
 
-- ✅ libretro core: **Genesis Plus GX**<br>
+- ✅ libretro core: **Genesis Plus GX**
   - Most recommended
 - ✅ libretro core: **Picodrive**
-- ❌ libretro core: **Blastem**<br>
+- ❌ libretro core: **Blastem**
   - While some achievements may work, the core has issues with the Game RAM portion of memory.
 - ✅ BizHawk core: **Genplus-gx** (Genesis Plus GX)
 
 #### Intellivision
 
-- ✅ libretro core: **FreeIntV**<br>
-  - Crashes when game is reset<br>
+- ✅ libretro core: **FreeIntV**
+  - Crashes when game is reset
   - Some crashes which might be related to Intellivoice
 - ✅ BizHawk core: **IntelliHawk**
 
@@ -278,15 +281,15 @@
 - ❌ _Not supported_ - needs hashing method and memory map
 - ❌ libretro core: **dosbox-core**
 - ❌ libretro core: **dosbox-SVN**
-- ❌ libretro core: **dosbox-pure**<br>
-  - Needs a way to prevent launching with user-specified command line parameters<br>
-  - Needs a way to prevent TSRs<br>
+- ❌ libretro core: **dosbox-pure**
+  - Needs a way to prevent launching with user-specified command line parameters
+  - Needs a way to prevent TSRs
   - Needs a way to deactivate achievements if game drops to command prompt
 
 #### MSX
 
-- ✅ libretro core: **blueMSX**<br>
-  - Hash relies on .DSK file not being modified<br>
+- ✅ libretro core: **blueMSX**
+  - Hash relies on .DSK file not being modified
   - .DSK files appear to be unsupported if they also require a cartridge. There is a core option for this, but it doesn't seem to function properly. See "SD Snatcher", which used a 'sound' cartridge.
 - ❓ libretro core: **fMSX**
 
@@ -309,11 +312,11 @@
 #### NES / Famicom
 
 - ✅ Standalone emulator: **[RANes](https://retroachievements.org/download.php#ranes)**
-- ✅ libretro core: **FCEUmm**<br>
+- ✅ libretro core: **FCEUmm**
   - Most recommended
 - ✅ libretro core: **Mesen**
 - ✅ libretro core: **QuickNES**
-- ❌ libretro core: **NEStopia**<br>
+- ❌ libretro core: **NEStopia**
   - Does not map SRAM
   - PLEASE STOP USING THIS FOR ACHIEVEMENTS
 - ❓ libretro core: **Emux NES**
@@ -322,8 +325,8 @@
 #### Nintendo 3DS
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **Citra**<br>
-  - Only exposes 64MB of memory - documentation suggests there should be 128MB.<br>
+- ❌ libretro core: **Citra**
+  - Only exposes 64MB of memory - documentation suggests there should be 128MB.
   - Does not support save states
 - ❌ libretro core: **Citra 2018**
 - ❌ libretro core: **Citra Canary**
@@ -332,9 +335,9 @@
 
 - ✅ Standalone emulator: **[RAProject64](https://retroachievements.org/download.php#rap64)**
 - ✅ libretro core: **ParaLLEl N64**
-- ✅ libretro core: **Mupen64Plus-Next**<br>
+- ✅ libretro core: **Mupen64Plus-Next**
   - Most recommended
-- ⌛ BizHawk core: **Mupen64Plus**<br>
+- ⌛ BizHawk core: **Mupen64Plus**
   - Testing (there are some graphical issues that can be fixed using the angrylion plugin)
 
 #### Nintendo DS
@@ -369,18 +372,20 @@
 
 #### PC Engine | TurboGrafx-16 | SuperGrafx
 
-- ✅ libretro core: **Beetle PCE Fast**<br>
+- ✅ libretro core: **Beetle PCE Fast**
   - SuperGrafx games do not work on the Beetle PCE Fast core
-- ✅ libretro core: **Beetle SuperGrafx**<br>
+- ✅ libretro core: **Beetle SuperGrafx**
   - Most recommended
 - ✅ BizHawk core: **PCEHawk**
 
 #### PC Engine CD | TurboGrafx-CD
 
 - ✅ libretro core: **Beetle PCE Fast**
-- ✅ libretro core: **Beetle SuperGrafx**<br>
+- ✅ libretro core: **Beetle SuperGrafx**
   - Most recommended
 - ✅ BizHawk core: **PCEHawk**
+- ❌ libretro core: **Beetle PCE**
+  - Does not expose RAM needed for PC Engine CD
 
 #### PC-6001
 
@@ -388,20 +393,20 @@
 
 #### PC-8800
 
-- ✅ Standalone emulator: **[RAQuasi88](https://retroachievements.org/download.php#raquasi88)**<br>
+- ✅ Standalone emulator: **[RAQuasi88](https://retroachievements.org/download.php#raquasi88)**
   - Most recommended
-- ❌ libretro core: **quasi88**<br>
-  - NOT RECOMMENDED<br>
-  - PC-88VA not supported<br>
-  - 16 Apr 2022 - Cannot load m3u. Hash fails because core locks disk file.<br>
-  - 16 Apr 2022 - Attempting to load a single disk game in RALibretro just goes to "How many disks?" prompt. Seems to work in RetroArch<br>
+- ❌ libretro core: **quasi88**
+  - NOT RECOMMENDED
+  - PC-88VA not supported
+  - 16 Apr 2022 - Cannot load m3u. Hash fails because core locks disk file.
+  - 16 Apr 2022 - Attempting to load a single disk game in RALibretro just goes to "How many disks?" prompt. Seems to work in RetroArch
   - 16 Apr 2022 - RALibretro does not provide subsystem interface for loading multi-disk games
 
 #### PC-9800
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **Neko Project II Kai**<br>
-  - Memory is not exposed.<br>
+- ❌ libretro core: **Neko Project II Kai**
+  - Memory is not exposed.
     - It appears to be exposed in some games depending on the RAM size selected, but it seems like the machine RAM and not actually related to the game.
 - ❌ libretro core: **Neko Project II**
 
@@ -429,14 +434,14 @@
 
 #### PlayStation
 
-- ✅ Standalone emulator: **[DuckStation](https://www.duckstation.org/wiki/Main_Page)**<br>
+- ✅ Standalone emulator: **[DuckStation](https://www.duckstation.org/wiki/Main_Page)**
   - There may be memory leak and/or burn-in when using save states. Softcore players beware!
-- ✅ libretro core: **Beetle PSX HW**<br>
+- ✅ libretro core: **Beetle PSX HW**
   - Most recommended
 - ✅ libretro core: **Beetle PSX**
 - ✅ libretro core: **SwanStation**
-- ❌ libretro core: **PCSX ReARMed**<br>
-  - BIOS are not required for this core and will zero out the Kernal RAM.<br>
+- ❌ libretro core: **PCSX ReARMed**
+  - BIOS are not required for this core and will zero out the Kernal RAM.
   - Technically supported; not recommended.
 - ❓ BizHawk core: **Octoshock** (Mednafen)
 - ❓ BizHawk core: **Nymashock** (Mednafen)
@@ -444,30 +449,30 @@
 
 #### PlayStation 2
 
-- ✅ Standalone emulator: **[PCSX2](https://pcsx2.net/)**<br>
+- ✅ Standalone emulator: **[PCSX2](https://pcsx2.net/)**
   - PCSX2 is currently **the only officially supported** option for earning achievements.
-- ❌ Standalone emulator: AetherSX2
-  - No longer being developed, has known incompatiblities
-- ❌ Standalone emulator: NetherSX2
-- ❌ libretro core: **LRPS2**<br>
-  - Still in alpha state<br>
+- ❌ Standalone emulator: **AetherSX2**
+  - No longer being developed, has known incompatibilities
+- ❌ Standalone emulator: **NetherSX2**
+- ❌ libretro core: **LRPS2**
+  - Still in alpha state
   - Does not expose memory
-- ❌ libretro core: **Play!**<br>
-  - Low compatibility with most commerical games<br>
+- ❌ libretro core: **Play!**
+  - Low compatibility with most commerical games
   - Black screen with stuttering sound
 
 #### PlayStation Portable
 
-- ✅ Standalone emulator: **[PPSSPP](https://www.ppsspp.org/download/)**<br>
+- ✅ Standalone emulator: **[PPSSPP](https://www.ppsspp.org/download/)**
   - Does not support RAIntegration at this time, so achievement developers are unable to troubleshoot potential issues.
-- ✅ libretro core: **PPSSPP**<br>
-  - Loading save states too fast can cause it to crash<br>
+- ✅ libretro core: **PPSSPP**
+  - Loading save states too fast can cause it to crash
   - Some games have graphical issues
 
 #### PocketStation
 
 - ❌ _Not supported_ - needs console ID, hashing method and memory map
-- ❌ libretro core: **pockystation**<br>
+- ❌ libretro core: **pockystation**
   - Core doesn't seem functional, even in RetroArch
 
 #### Pokemon Mini
@@ -482,9 +487,11 @@
 
 #### Sega 32X
 
-- ✅ libretro core: **PicoDrive**<br>
-  - Several games are problematic<br>
+- ✅ libretro core: **PicoDrive**
+  - Several games are problematic, use BizHawk if an achievement shows as Unsupported
   - Appears to still have unmapped RAM
+- ✅ BizHawk core: **PicoDrive**
+  - Most recommended
 
 #### Sega CD
 
@@ -494,24 +501,24 @@
 
 #### Sega Dreamcast
 
-- ✅ libretro core: **flycast**<br>
+- ✅ libretro core: **flycast**
   - Must disable threaded rendering to use save states
 - ❓ libretro core: **Flycast GLES2**
 
 #### Sega Pico
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **picodrive**<br>
+- ❌ libretro core: **picodrive**
   - Needs controls related to turning pages in the attached books
 
 #### Sega Saturn
 
-- ✅ libretro core: **Beetle Saturn**<br>
+- ✅ libretro core: **Beetle Saturn**
   - The only _recommended_ core
-- ❌ libretro core: **Yabause**<br>
+- ❌ libretro core: **Yabause**
   - Technically supported; not recommended.
-- ❌ libretro core: **Kronos**<br>
-  - Saving and loading states often locks up the UI in RALibretro<br>
+- ❌ libretro core: **Kronos**
+  - Saving and loading states often locks up the UI in RALibretro
   - Technically supported; not recommended.
 - ❓ libretro core: **YabaSanshiro**
 - ⌛ BizHawk core: **Saturnus** (Mednafen)
@@ -520,7 +527,7 @@
 #### SG-1000
 
 - ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
-- ✅ libretro core: **Genesis Plus GX**<br>
+- ✅ libretro core: **Genesis Plus GX**
   - Most recommended
 - ✅ libretro core: **blueMSX**
 - ❌ libretro core: **Gearsystem**
@@ -529,19 +536,19 @@
 #### Sharp X1
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **X1 Millennium**<br>
+- ❌ libretro core: **X1 Millennium**
   - 16 Apr 2022 - Disk writes modify source media, which breaks hashing
 
 #### Sharp X68K
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **px68k**<br>
+- ❌ libretro core: **px68k**
   - Crashes RALibretro upon loading a game
 
 #### SNES | Super Famicom | Satellaview | Sufami Turbo
 
 - ✅ Standalone emulator: **[RASnes9x](https://retroachievements.org/download.php#rasnes9x)**
-- ✅ libretro core: **Snes9x (Current)**<br>
+- ✅ libretro core: **Snes9x (Current)**
   - Most recommended
 - ✅ libretro core: **Mesen-S**
 - ❓ libretro core: **Beetle bsnes**
@@ -560,7 +567,7 @@
 - ❓ libretro core: **Snes9x 2002**
 - ❓ libretro core: **Snes9x 2005**
 - ❓ libretro core: **Snes9x 2005+**
-- ❌ libretro core: **Snes9x 2010**<br>
+- ❌ libretro core: **Snes9x 2010**
   - PLEASE STOP USING THIS FOR ACHIEVEMENTS!!!!
 - ❓ BizHawk core: **BSNES**
 - ❓ BizHawk core: **BSNESv115+**
@@ -572,28 +579,28 @@
 
 #### Super Cassette Vision
 
-- ❌ libretro core: **EmuSCV**<br>
-  - Unfinished according to [libretro docs](https://docs.libretro.com/library/emuscv/).<br>
+- ❌ libretro core: **EmuSCV**
+  - Unfinished according to [libretro docs](https://docs.libretro.com/library/emuscv/).
   - Does not expose memory. Appears to [export a save state](https://gitlab.com/MaaaX-EmuSCV/libretro-emuscv/-/blob/master/src/libretro.cpp#L223-229) via the RETRO_MEMORY_SAVE_RAM interface, which we try to shoehorn into $E000 as that's what's flagged as Cartridge RAM for the system.
 
 #### Thomson TO8/TO8D
 
 - ❌ _Not supported_ - needs hashing method
-- ❌ libretro core: **Theodore**<br>
-  - Seems to work<br>
+- ❌ libretro core: **Theodore**
+  - Seems to work
   - Uncertain how core handles writing to disk/tape. May affect hashing.
 
 #### TI-83
 
-- ⌛ libretro core: **Numero**<br>
+- ⌛ libretro core: **Numero**
   - Testing
-- ⌛ BizHawk core: **TI83Hawk**<br>
+- ⌛ BizHawk core: **TI83Hawk**
   - Testing
 
 #### TIC-80
 
 - ❌ _Not supported_ - needs hashing method
-- ❌ libretro core: **TIC-80**<br>
+- ❌ libretro core: **TIC-80**
   - Doesn't export memory correctly. Can only see 8 bytes.
 
 #### Uzebox
@@ -630,9 +637,9 @@
 
 #### Wii
 
-- ⌛ Standalone emulator: **Dolphin**<br>
+- ⌛ Standalone emulator: **Dolphin**
   - Testing
-- ⌛ libretro core: **Dolphin**<br>
+- ⌛ libretro core: **Dolphin**
   - Testing
 
 #### Wii U
@@ -662,17 +669,17 @@
 #### ZX81
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **EightyOne**<br>
+- ❌ libretro core: **EightyOne**
   - Memory not exposed
 
 #### ZX Spectrum
 
 - ❌ _Not supported_ - needs hashing method and memory map
-- ❌ libretro core: **FUSE**<br>
-  - Requires ability to map keyboard to port 3<br>
+- ❌ libretro core: **FUSE**
+  - Requires ability to map keyboard to port 3
   - Uncertain about save support. Cannot seem to insert save disk
-- ⌛ - BizHawk core: **ZXHawk**<br>
-  - Hashing needs to be corrected<br>
+- ⌛ - BizHawk core: **ZXHawk**
+  - Hashing needs to be corrected
   - Testing
 
 More details on BizHawk cores can be found [here](https://tasvideos.org/BizHawk).


### PR DESCRIPTION
1. Removed scattered HTML line breaks that didn't do anything.
2. Added BizHawk's PicoDrive core as supported.
3. Added both BizHawk's and libretro's MAME cores and marked them as unsupported.
4. Added libretro's Beetle PCE under PC Engine CD and marked it as unsupported.
5. Added additional details/qualifiers relating to 32X, Atari 2600, and PC Engine CD support.