### PR TITLE
fix: use npm in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 on: [pull_request]
 
-env:
-  PNPM_VERSION: 9.1.2
-
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -12,15 +9,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
       - name: Use Node 20
         uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: Install
-        run: pnpm install
+        run: npm install
       - name: Build Vitepress
-        run: pnpm build
+        run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-pnpm-lock.yaml


### PR DESCRIPTION
The current project doesn't use `pnpm`. This change makes the workflow rely on `npm`.