### PR TITLE
Update rich-presence.md

### DIFF
--- a/docs/developer-docs/rich-presence.md
+++ b/docs/developer-docs/rich-presence.md
@@ -293,9 +293,9 @@ If you make changes to the `XXX-Rich.txt` file, and reselect the menu option, it
 
 ### Condition Syntax
 
-Rich Presence files utilize [Condition Syntax](developer-docs/condition-syntax) when referencing addresses. When developing Rich Presence you should use this syntax so that the Rich Presence Monitor can read the address as you expect it to. Condition Syntax covers the following ways to reference addresses:
+Rich Presence files utilize [Condition Syntax](/developer-docs/condition-syntax) when referencing addresses. When developing Rich Presence you should use this syntax so that the Rich Presence Monitor can read the address as you expect it to. Condition Syntax covers the following ways to reference addresses:
 -  [Memory Sizes](/developer-docs/condition-syntax#memory-sizes). This allows the Rich Presence script to tell the difference between an 8-bit address and a 32-bit address, for example.
-- [Prefixes](/developer-docs/condition-syntax#prefixes). This allows the Rich Presence script to apply special modifiers to the address, i.e. if the address is in [BCD format](developer-docs/value-definition.html#binary-coded-decimal).  
+- [Prefixes](/developer-docs/condition-syntax#prefixes). This allows the Rich Presence script to apply special modifiers to the address, i.e. if the address is in [BCD format](/developer-docs/value-definition.html#binary-coded-decimal).  
 - [Logical Flags](/developer-docs/condition-syntax#logical-flags). This can be helpful if you need to do extra operations when displaying a specific value that may be spread across several addresses. 
 
 ### Parse Errors

--- a/docs/developer-docs/rich-presence.md
+++ b/docs/developer-docs/rich-presence.md
@@ -291,7 +291,12 @@ If you make changes to the `XXX-Rich.txt` file, and reselect the menu option, it
 
 **NOTE**: The `XXX-Rich.txt` file is overwritten with the current server data each time the game is opened. As long as you still have the file open in an editor, you can always save your changes over the updated file after reopening the game.
 
-Rich Presence files utilize Condition Syntax for [Memory Sizes](/developer-docs/condition-syntax#memory-sizes), [Prefixes](/developer-docs/condition-syntax#prefixes) and [Logical Flags](/developer-docs/condition-syntax#logical-flags). These are also represented if you copy and paste achievement logic from the [Achievement Editor](/developer-docs/achievement-development-overview#achievement-editor).
+### Condition Syntax
+
+Rich Presence files utilize [Condition Syntax](developer-docs/condition-syntax) when referencing addresses. When developing Rich Presence you should use this syntax so that the Rich Presence Monitor can read the address as you expect it to. Condition Syntax covers the following ways to reference addresses:
+-  [Memory Sizes](/developer-docs/condition-syntax#memory-sizes). This allows the Rich Presence script to tell the difference between an 8-bit address and a 32-bit address, for example.
+- [Prefixes](/developer-docs/condition-syntax#prefixes). This allows the Rich Presence script to apply special modifiers to the address, i.e. if the address is in [BCD format](developer-docs/value-definition.html#binary-coded-decimal).  
+- [Logical Flags](/developer-docs/condition-syntax#logical-flags). This can be helpful if you need to do extra operations when displaying a specific value that may be spread across several addresses. 
 
 ### Parse Errors
 


### PR DESCRIPTION
Put Condition Syntax into its own little subsection with a proper header and a bit more description as to what the links in that section refer to.

I don't know about other developers, but I've been finding that it's not immediately clear when reviewing this page as to where the syntax definitions are. This modification is made in the hope that it can at least make the Condition Syntax jump out a bit more on the page. 