### PR TITLE
add Junior Developer Rules doc

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -248,6 +248,10 @@ function sidebarDeveloperDocs(): DefaultTheme.SidebarItem[] {
           link: "/developer-docs/getting-started-as-an-achievement-developer",
         },
         {
+          text: "Junior Developer Program",
+          link: "/developer-docs/jr-dev-rules",
+        },
+        {
           text: "Game Identification",
           link: "/developer-docs/game-identification",
         },

--- a/docs/.vitepress/config/es.ts
+++ b/docs/.vitepress/config/es.ts
@@ -263,6 +263,10 @@ function sidebarDeveloperDocs(): DefaultTheme.SidebarItem[] {
           text: "Comenzando como Desarrollador de Logros",
           link: "/es/developer-docs/getting-started-as-an-achievement-developer",
         },
+        // {
+        //   text: "Junior Developer Program",
+        //   link: "/developer-docs/jr-dev-rules",
+        // },
         {
           text: "Identificación del Juego",
           link: "/es/developer-docs/game-identification",

--- a/docs/.vitepress/config/pt.ts
+++ b/docs/.vitepress/config/pt.ts
@@ -263,6 +263,10 @@ function sidebarDeveloperDocs(): DefaultTheme.SidebarItem[] {
           link: "/pt/developer-docs/getting-started-as-an-achievement-developer",
         },
         // {
+        //   text: "Junior Developer Program",
+        //   link: "/developer-docs/jr-dev-rules",
+        // },
+        // {
         //   text: "Identificação de Jogos",
         //   link: "/pt/developer-docs/game-identification",
         // },

--- a/docs/developer-docs/index.md
+++ b/docs/developer-docs/index.md
@@ -10,40 +10,42 @@ Now a brief description some pages you'll see in this section.
 
 2. [Getting Started as an Achievement Developer](/developer-docs/getting-started-as-an-achievement-developer): it's for the very first contact with cheevos development tools (Memory Inspector and other Achievements dialogs). **IF YOU ARE A COMPLETE NEWBIE, START HERE!**
 
-3. [Achievement Scoring](/developer-docs/achievement-scoring): a guide to deciding point totals for achievements
+3. [Junior Developer Program Rules](/developer-docs/jr-dev-rules): ruleset governing the Junior Developer Program
 
-4. [Memory Inspector Overview](/developer-docs/memory-inspector): detailed look at one of an achievement developer's most used tools.
+4. [Achievement Scoring](/developer-docs/achievement-scoring): a guide to deciding point totals for achievements
 
-5. [Achievement Logic Features](/orphaned/achievement-logic-features): describes the available tools a developer have in order to improve the logic behind the achievements, such as delta values, hit counts, ResetIf, PauseIf, Alt groups, etc.
+5. [Memory Inspector Overview](/developer-docs/memory-inspector): detailed look at one of an achievement developer's most used tools.
 
-6. [Real Examples](/developer-docs/real-examples): showing real examples and breaking down the logic behind them. **AWESOME LEARNING RESOURCE!**
+6. [Achievement Logic Features](/orphaned/achievement-logic-features): describes the available tools a developer have in order to improve the logic behind the achievements, such as delta values, hit counts, ResetIf, PauseIf, Alt groups, etc.
 
-7. [Achievement Templates](/developer-docs/achievement-templates): some generic templates to get inspiration.
+7. [Real Examples](/developer-docs/real-examples): showing real examples and breaking down the logic behind them. **AWESOME LEARNING RESOURCE!**
 
-8. [Tips and Tricks](/developer-docs/tips-and-tricks): general tips and tricks about memory digging and achievement creation.
+8. [Achievement Templates](/developer-docs/achievement-templates): some generic templates to get inspiration.
 
-9. [Difficulty Scale and Balance](/developer-docs/difficulty-scale-and-balance): guidelines/suggestions on how to balance the difficulty of your achievement set.
+9. [Tips and Tricks](/developer-docs/tips-and-tricks): general tips and tricks about memory digging and achievement creation.
 
-10. [Achievement Design](/developer-docs/achievement-design): a guide on how to think about and design good achievements, not the technical side but the conceptual.
+10. [Difficulty Scale and Balance](/developer-docs/difficulty-scale-and-balance): guidelines/suggestions on how to balance the difficulty of your achievement set.
 
-11. [Set Development Roadmap](/developer-docs/set-development-roadmap): suggestions of steps to take in order to create a really neat achievement set.
+11. [Achievement Design](/developer-docs/achievement-design): a guide on how to think about and design good achievements, not the technical side but the conceptual.
 
-12. [Achievement Set Revisions](/guidelines/content/achievement-set-revisions): information on revisions, rescores, and the icon gauntlet.
+12. [Set Development Roadmap](/developer-docs/set-development-roadmap): suggestions of steps to take in order to create a really neat achievement set.
 
-13. [Subsets](/guidelines/content/subsets): an advanced topic on creating special challenge sets and how to release them.
+13. [Achievement Set Revisions](/guidelines/content/achievement-set-revisions): information on revisions, rescores, and the icon gauntlet.
 
-14. [Badge and Icon Creation](/guidelines/content/badge-and-icon-guidelines): some guidelines and tips about badge/icon creation.
+14. [Subsets](/guidelines/content/subsets): an advanced topic on creating special challenge sets and how to release them.
 
-15. [Leaderboards](/developer-docs/leaderboards): instructions on how to create Leaderboards for a game.
+15. [Badge and Icon Creation](/guidelines/content/badge-and-icon-guidelines): some guidelines and tips about badge/icon creation.
 
-16. [Rich Presence](/developer-docs/rich-presence): how to write Rich Presence Scripts.
+16. [Leaderboards](/developer-docs/leaderboards): instructions on how to create Leaderboards for a game.
 
-17. [Working with the Right ROM](/guidelines/content/working-with-the-right-rom): information on using correct ROMs and hashes.
+17. [Rich Presence](/developer-docs/rich-presence): how to write Rich Presence Scripts.
 
-18. [Game Identification](/developer-docs/game-identification): details on the hashing methods used for each system.
+18. [Working with the Right ROM](/guidelines/content/working-with-the-right-rom): information on using correct ROMs and hashes.
 
-19. [Emulator Support and Issues](/general/emulator-support-and-issues): details on both supported and unsupported cores, testing progress, etc.
+19. [Game Identification](/developer-docs/game-identification): details on the hashing methods used for each system.
 
-20. [Achievements for ROM Hacks](/guidelines/content/achievements-for-rom-hacks): a detailed guide for developers on the proper inclusion (and approval) of ROM Hacks.
+20. [Emulator Support and Issues](/general/emulator-support-and-issues): details on both supported and unsupported cores, testing progress, etc.
 
-21. [Console Specific Tips](/developer-docs/console-specific-tips): knowing the peculiarities of your favorite console can help you with memory digging.
+21. [Achievements for ROM Hacks](/guidelines/content/achievements-for-rom-hacks): a detailed guide for developers on the proper inclusion (and approval) of ROM Hacks.
+
+22. [Console Specific Tips](/developer-docs/console-specific-tips): knowing the peculiarities of your favorite console can help you with memory digging.

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -27,6 +27,7 @@ To join the Junior Developer Program, the following requirements must be met:
 The following rules apply to all Junior Developers:
 - May only create achievements, leaderboards and Rich Presence for a set on which they have an active claim
   - This means no working on any sets that are not claimed.  Failure to adhere to this rule may result in dismissal from the Junior Developer Program
+  - Junior Developers may practice RAM digging games for which they do not have a claim, but shall not publish any code notes
 - May not make a new claim while they have any open tickets
 - Will prioritize resolving open tickets over development of a new set. If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
 - Are not eligible to participate in collaborations
@@ -54,6 +55,6 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 ### Removal From Junior Developer Program
 
 Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
-- 1 month of inactivity with either active development or RA in general
+- 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) with either active development or RA in general
   - May request immediate restoration of role by submitting a full request per [Entry Requirements](#entry-requirements)
 - Violations of the RA Developer Code of Conduct or the rules set forth within this document

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -32,7 +32,7 @@ The following rules apply to all Junior Developers:
 - Are not eligible to participate in collaborations
 - Are not eligible to revise sets other than ones they've solely authored
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
-- May not make a claim without Code Reviewer approval on a Dreamcast game created with [Windows CE](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
+- May not make a claim without Code Reviewer approval on a Dreamcast using the  [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
   - Must make a development request in #jr-dev-forum after at least 1 set has been published
 - May not make a subset without Code Reviewer approval
   - Must make subset request in #jr-dev-forum. If approved, subset is subject to [Subset Rules](https://docs.retroachievements.org/guidelines/content/subsets.html)

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -57,5 +57,5 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 
 Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
 - 1 month of inactivity with either active development or RA in general
-  - May request immediate restoration of role by submitting a full request per [#Entry Requirements]
+  - May request immediate restoration of role by submitting a full request per [Entry Requirements](#entry-requirements)
 - Violations of the RA Developer Code of Conduct or the rules set forth within this document

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -48,8 +48,6 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 - May not request a code review until at least 7 days after claiming a set
 - Will complete the ["Am I Ready for Review" checklist](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) prior to requesting a Code Review
 - Will describe in the Code Review request the self testing method used in order to validate set stability
-- Will submit a play test request in #play-test-requests immediately following a set being entered into the [Code Review backlog](https://docs.google.com/spreadsheets/d/e/2PACX-1vSl4tRG-wV1lxtb-2ZJYRoM0VLnQPYoQO1jOVRmb8TFWldFJGr7RrO6-I-c6rWK0XsZ1h5pJEOStjmQ/pubhtml?gid=1582422742&single=true)
-
 
 **Sets that fail to meet Code Review request requirements will be refused entry into the Code Review backlog until remedied**
 

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -1,6 +1,6 @@
 ---
 title: Junior Developer Program Rules
-description: Consolidates scattered junior developer program rules, adds clarification and introduces some new rules
+description: Comprehensive guidelines for the Junior Developer program, including rules, guidelines, and clarifications.
 ---
 
 # Junior Developer Program Rules

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -14,9 +14,9 @@ The purpose of the Junior Developer Program is to assist interested people with 
 ### Entry Requirements
 
 To join the Junior Developer Program, the following requirements must be met:
-- RetroAchievements account must be not be banned or suspended from achievement development or involuntarily untracked from competitive leaderboards
+- RetroAchievements account must not be banned or suspended from achievement development or involuntarily untracked from competitive leaderboards
 - Must have a Discord account verified on the [RetroAchievements Discord server](https://discord.gg/dq2E4hE)
-- Request the Junior Developer role in role-request channel in the General section of the RA discord server
+- Request the Junior Developer role in #role-request channel in the General section of the RA discord server
   - Must include an RA profile link
   - Must state the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
   - Read through all [RetroAchievements Developer Docs](https://docs.retroachievements.org/developer-docs/) and fill out and post a [Set Design Template](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
@@ -31,11 +31,11 @@ The following rules apply to all Junior Developers:
 - Will prioritize resolving open tickets over development of a new set. If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
 - Are not eligible to participate in collaborations
 - Are not eligible to revise sets other than ones they've solely authored
-  - Must make a revision request in #jr-dev-forums detailing the revision plan. The Code Reviewer team will consider the request for approval
+  - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
 - May not make a claim without Code Reviewer approval on a Dreamcast game created with [Windows CE](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
-  - Must make a development request in #jr-dev-forums after at least 1 set has been published
+  - Must make a development request in #jr-dev-forum after at least 1 set has been published
 - May not make a subset without Code Reviewer approval
-  - Must make subset request in #jr-dev-forums. If approved, subset is subject to [Subset Rules](https://docs.retroachievements.org/guidelines/content/subsets.html)
+  - Must make subset request in #jr-dev-forum. If approved, subset is subject to [Subset Rules](https://docs.retroachievements.org/guidelines/content/subsets.html)
     - May request to create a subset in addition to a primary claim if both are for the same game
 - May make a maximum of 2 sets for hacks during the program
 

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -55,7 +55,7 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 ### Removal From Junior Developer Program
 
 Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
+- Violations of the RA Developer Code of Conduct or the rules set forth within this document
 - 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) in either active development or RA in general
   - First time inactivity removals may request immediate restoration of Junior Developer role
   - Subsequent inactivity removals will be subject to a 30-day cool down, beginning upon demotion action. After cool down, must submit a full rejoin request per [Entry Requirements](#entry-requirements)
-- Violations of the RA Developer Code of Conduct or the rules set forth within this document

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -55,6 +55,7 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 ### Removal From Junior Developer Program
 
 Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
-- 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) with either active development or RA in general
-  - May request immediate restoration of role by submitting a full request per [Entry Requirements](#entry-requirements)
+- 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) in either active development or RA in general
+  - First time inactivity removals may request immediate restoration of Junior Developer role
+  - Subsequent inactivity removals will be subject to a 30-day cool down, beginning upon demotion action. After cool down, must submit a full rejoin request per [Entry Requirements](#entry-requirements)
 - Violations of the RA Developer Code of Conduct or the rules set forth within this document

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -1,6 +1,6 @@
 ---
 title: Junior Developer Program Rules
-description: Comprehensive guidelines for the Junior Developer program, including rules, guidelines, and clarifications.
+description: Comprehensive guidelines for the Junior Developer Program, including rules, guidelines, and clarifications.
 ---
 
 # Junior Developer Program Rules
@@ -16,8 +16,8 @@ The purpose of the Junior Developer Program is to assist interested people with 
 To join the Junior Developer Program, the following requirements must be met:
 - RetroAchievements account must not be banned or suspended from achievement development or involuntarily untracked from competitive leaderboards
 - Have a Discord account verified on the [RetroAchievements Discord server](https://discord.gg/dq2E4hE)
-- Request the Junior Developer role in #role-request channel in the General section of the RA discord server
-  - Include RA profile link
+- Request the Junior Developer role in #role-request channel in the General section of the RA Discord server
+  - Include your RA profile link
   - State the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
   - Read through all [RetroAchievements Developer Docs](https://docs.retroachievements.org/developer-docs/) and fill out and post a [Set Design Plan](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
 - Unless specifically authorized by [Developer Compliance](https://retroachievements.org/messages/create?to=DevCompliance), all requirements in this section must be met to gain entry to the Junior Developer Program regardless of previous RA experience
@@ -54,7 +54,7 @@ Junior Developers are required to ensure sets they submit for Code Review are of
 
 ### Removal From Junior Developer Program
 
-Participation in the Junior Developer program is not an entitlement or right. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
+Participation in the Junior Developer Program is not an entitlement or right. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
 - Violations of the RA Developer Code of Conduct or the rules set forth within this document
 - 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) in either active development or RA in general
   - First time inactivity removals may request immediate restoration of Junior Developer role

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -15,11 +15,11 @@ The purpose of the Junior Developer Program is to assist interested people with 
 
 To join the Junior Developer Program, the following requirements must be met:
 - RetroAchievements account must not be banned or suspended from achievement development or involuntarily untracked from competitive leaderboards
-- Must have a Discord account verified on the [RetroAchievements Discord server](https://discord.gg/dq2E4hE)
+- Have a Discord account verified on the [RetroAchievements Discord server](https://discord.gg/dq2E4hE)
 - Request the Junior Developer role in #role-request channel in the General section of the RA discord server
-  - Must include an RA profile link
-  - Must state the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
-  - Read through all [RetroAchievements Developer Docs](https://docs.retroachievements.org/developer-docs/) and fill out and post a [Set Design Template](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
+  - Include RA profile link
+  - State the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
+  - Read through all [RetroAchievements Developer Docs](https://docs.retroachievements.org/developer-docs/) and fill out and post a [Set Design Plan](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
 - Unless specifically authorized by [Developer Compliance](https://retroachievements.org/messages/create?to=DevCompliance), all requirements in this section must be met to gain entry to the Junior Developer Program regardless of previous RA experience
 
 ### Rules and Restrictions
@@ -30,8 +30,8 @@ The following rules apply to all Junior Developers:
   - Junior Developers may practice RAM digging games for which they do not have a claim, but shall not publish any code notes
 - May not make a new claim while they have any open tickets
 - Will prioritize resolving open tickets over development of a new set. If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
-- Are not eligible to participate in collaborations
-- Are not eligible to [revise](https://docs.retroachievements.org/guidelines/content/achievement-set-revisions.html) sets other than ones they've solely authored
+- Not eligible to participate in collaborations
+- Not eligible to [revise](https://docs.retroachievements.org/guidelines/content/achievement-set-revisions.html) sets other than ones they've solely authored
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
 - May not make a claim without Code Reviewer approval on a Dreamcast using the [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
   - Must make a development request in #jr-dev-forum after at least 1 set has been published
@@ -42,19 +42,19 @@ The following rules apply to all Junior Developers:
 
 ### Code Review Requests
 
-Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make them. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Review.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
-- Will check the set to be submitted against the ["Am I Ready for Review"](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) guide prior to requesting a Code Review
+Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Review.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
+- Must follow the ["Am I Ready for Review"](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) guide prior to requesting a Code Review
 - May not submit sets that fail to conform to the [Writing Policy](https://docs.retroachievements.org/guidelines/content/writing-policy.html) or [Code Note Standards](https://docs.retroachievements.org/guidelines/content/code-notes.html)
 - May not submit sets that do not have original achievement badges
 - May not submit sets that do not have Rich Presence
 - May not request a code review until at least 7 days after claiming a set
 - Will describe in the Code Review request the self testing method used in order to validate set stability
 
-**Sets that fail to meet Code Review request requirements will be refused entry into the Code Review backlog until remedied**
+**Sets that fail to meet Code Review request requirements will be refused entry into the Code Review backlog until remediated**
 
 ### Removal From Junior Developer Program
 
-Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
+Participation in the Junior Developer program is not an entitlement or right. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
 - Violations of the RA Developer Code of Conduct or the rules set forth within this document
 - 1 month of [inactivity](https://docs.retroachievements.org/guidelines/developers/code-of-conduct.html#inactivity) in either active development or RA in general
   - First time inactivity removals may request immediate restoration of Junior Developer role

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -1,0 +1,61 @@
+---
+title: Junior Developer Program Rules
+description: Consolidates scattered junior developer program rules, adds clarification and introduces some new rules
+---
+
+# Junior Developer Program Rules
+
+[[toc]]
+
+## Overview
+
+The purpose of the Junior Developer Program is to assist interested people with learning how to create and maintain high quality achievement sets for RetroAchievements. Junior Developers are required to understand and abide by the [Developer Code of Conduct](https://docs.retroachievements.org/guidelines/users/code-of-conduct.html) except where specifically addressed by this document.
+
+### Entry Requirements
+
+To join the Junior Developer Program, the following requirements must be met:
+- RetroAchievements account must be not be banned or suspended from achievement development or involuntarily untracked from competitive leaderboards
+- Must have a Discord account verified on the [RetroAchievements Discord server](https://discord.gg/dq2E4hE)
+- Request the Junior Developer role in role-request channel in the General section of the RA discord server
+  - Must include an RA profile link
+  - Must state the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
+  - Read through all [RetroAchievements Developer Docs](https://docs.retroachievements.org/developer-docs/) and fill out and post a [Set Design Template](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
+- Unless specifically authorized by [Developer Compliance](https://retroachievements.org/messages/create?to=DevCompliance), all requirements in this section must be met to gain entry to the Junior Developer Program regardless of previous RA experience
+
+### Rules and Restrictions
+
+The following rules apply to all Junior Developers:
+- May only create achievements, leaderboards and Rich Presence for a set on which they have an active claim
+  - This means no working on any sets that are not claimed.  Failure to adhere to this rule may result in dismissal from the Junior Developer Program
+- May not make a new claim while they have any open tickets
+- Will prioritize resolving open tickets over development of a new set. If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
+- Are not eligible to participate in collaborations
+- Are not eligible to revise sets other than ones they've solely authored
+  - Must make a revision request in #jr-dev-forums detailing the revision plan. The Code Reviewer team will consider the request for approval
+- May not make a claim without Code Reviewer approval on a Dreamcast game created with [Windows CE](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
+  - Must make a development request in #jr-dev-forums after at least 1 set has been published
+- May not make a subset without Code Reviewer approval
+  - Must make subset request in #jr-dev-forums. If approved, subset is subject to [Subset Rules](https://docs.retroachievements.org/guidelines/content/subsets.html)
+    - May request to create a subset in addition to a primary claim if both are for the same game
+- May make a maximum of 2 sets for hacks during the program
+
+### Code Review Requests
+
+Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make them. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Reviewer.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
+- May not submit sets that fail to conform to the [Writing Policy](https://docs.retroachievements.org/guidelines/content/writing-policy.html) or [Code Note Standards](https://docs.retroachievements.org/guidelines/content/code-notes.html)
+- May not submit sets that do not have original achievement badges
+- May not submit sets that do not have Rich Presence
+- May not request a code review until at least 7 days after claiming a set
+- Will complete the ["Am I Ready for Review" checklist](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) prior to requesting a Code Review
+- Will describe in the Code Review request the self testing method used in order to validate set stability
+- Will submit a play test request in #play-test-requests immediately following a set being entered into the [Code Review backlog](https://docs.google.com/spreadsheets/d/e/2PACX-1vSl4tRG-wV1lxtb-2ZJYRoM0VLnQPYoQO1jOVRmb8TFWldFJGr7RrO6-I-c6rWK0XsZ1h5pJEOStjmQ/pubhtml?gid=1582422742&single=true)
+
+
+**Sets that fail to meet Code Review request requirements will be refused entry into the Code Review backlog until remedied**
+
+### Removal From Junior Developer Program
+
+Participation in the Junior Developer program is not an entitlement. Junior Developers are expected to take the program seriously, put forth significant effort, seek assistance when unable to figure something out, strive to make the highest quality set possible and maturely accept and apply Code Reviewer feedback. Junior developers may be temporarily or permanently removed from the program for the following reasons:
+- 1 month of inactivity with either active development or RA in general
+  - May request immediate restoration of role by submitting a full request per [#Entry Requirements]
+- Violations of the RA Developer Code of Conduct or the rules set forth within this document

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -43,11 +43,11 @@ The following rules apply to all Junior Developers:
 ### Code Review Requests
 
 Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make them. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Reviewer.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
+- Will check the set to be submitted against the ["Am I Ready for Review"](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) guide prior to requesting a Code Review
 - May not submit sets that fail to conform to the [Writing Policy](https://docs.retroachievements.org/guidelines/content/writing-policy.html) or [Code Note Standards](https://docs.retroachievements.org/guidelines/content/code-notes.html)
 - May not submit sets that do not have original achievement badges
 - May not submit sets that do not have Rich Presence
 - May not request a code review until at least 7 days after claiming a set
-- Will complete the ["Am I Ready for Review" checklist](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) prior to requesting a Code Review
 - Will describe in the Code Review request the self testing method used in order to validate set stability
 
 **Sets that fail to meet Code Review request requirements will be refused entry into the Code Review backlog until remedied**

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -31,7 +31,7 @@ The following rules apply to all Junior Developers:
 - May not make a new claim while they have any open tickets
 - Will prioritize resolving open tickets over development of a new set. If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
 - Are not eligible to participate in collaborations
-- Are not eligible to revise sets other than ones they've solely authored
+- Are not eligible to [revise](https://docs.retroachievements.org/guidelines/content/achievement-set-revisions.html) sets other than ones they've solely authored
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
 - May not make a claim without Code Reviewer approval on a Dreamcast using the [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
   - Must make a development request in #jr-dev-forum after at least 1 set has been published

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -33,7 +33,7 @@ The following rules apply to all Junior Developers:
 - Are not eligible to participate in collaborations
 - Are not eligible to revise sets other than ones they've solely authored
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
-- May not make a claim without Code Reviewer approval on a Dreamcast using the  [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
+- May not make a claim without Code Reviewer approval on a Dreamcast using the [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2 or future 6th+ generation consoles at the discretion of the Code Review team
   - Must make a development request in #jr-dev-forum after at least 1 set has been published
 - May not make a subset without Code Reviewer approval
   - Must make subset request in #jr-dev-forum. If approved, subset is subject to [Subset Rules](https://docs.retroachievements.org/guidelines/content/subsets.html)
@@ -42,7 +42,7 @@ The following rules apply to all Junior Developers:
 
 ### Code Review Requests
 
-Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make them. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Reviewer.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
+Junior Developers are required to ensure sets they submit for Code Review are of the highest quality they can make them. If a set has known issues, Junior Developers must resolve them prior to requesting a Code Review.  Code Reviewers are available to answer questions and offer guidance to assist Junior Developers resolve issues.  The following rules apply to all Junior Developers intending to submit a Code Review request:
 - Will check the set to be submitted against the ["Am I Ready for Review"](https://docs.google.com/document/d/e/2PACX-1vSYRcYpyN0W8oP9Ho0YMiUutZEs-np4JDL-Be5IfuR5oyG_92wVwgwA5BkTHywK_olmzRBjpZGehKM6/pub) guide prior to requesting a Code Review
 - May not submit sets that fail to conform to the [Writing Policy](https://docs.retroachievements.org/guidelines/content/writing-policy.html) or [Code Note Standards](https://docs.retroachievements.org/guidelines/content/code-notes.html)
 - May not submit sets that do not have original achievement badges


### PR DESCRIPTION
Adds page of all rules governing the Junior Developer Program.

This doc is intended to be a one-stop shop for people to understand the requirements for participation in the Junior Developer Program including how to join, how to remain in good standing and the requirements for requesting a code review.  Previously, rules were scattered in various locations such as the welcome message, #jr-devs discord pins, #developer-news announcements, developer code of conduct docs and forum posts.

This doc has been reviewed and approved by the Code Reviewer team.  Each new rule was separately discussed and voted on.