### PR TITLE
Add guidance for adding hashes to primary sets

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -223,6 +223,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
           link: "/guidelines/content/achievement-set-revisions",
         },
         {
+          text: "Adding Additional Hashes",
+          link: "/guidelines/content/adding-hashes",
+        },
+        {
           text: "Achievements for ROM Hacks",
           link: "/guidelines/content/achievements-for-rom-hacks",
         },

--- a/docs/.vitepress/config/es.ts
+++ b/docs/.vitepress/config/es.ts
@@ -238,6 +238,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
           text: "Revisiones del Conjunto de Logros",
           link: "/es/guidelines/content/achievement-set-revisions",
         },
+        // {
+        //   text: "Adding Additional Hashes",
+        //   link: "/es/guidelines/content/adding-hashes",
+        // },
         {
           text: "Logros para ROM Hacks",
           link: "/es/guidelines/content/achievements-for-rom-hacks",

--- a/docs/.vitepress/config/pt.ts
+++ b/docs/.vitepress/config/pt.ts
@@ -237,6 +237,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
     //       text: "Revisões do Conjunto de Conquistas",
     //       link: "/pt/guidelines/content/achievement-set-revisions",
     //     },
+            // {
+        //   text: "Adding Additional Hashes",
+        //   link: "/pt/guidelines/content/adding-hashes",
+        // },
     //     {
     //       text: "Conquistas para ROM Hacks",
     //       link: "/pt/guidelines/content/achievements-for-rom-hacks",

--- a/docs/guidelines/content/achievements-for-rom-hacks.md
+++ b/docs/guidelines/content/achievements-for-rom-hacks.md
@@ -18,13 +18,13 @@ Any hack or patch intended to be linked to a primary achievement set by anyone o
 - If a hack has sufficient enough differences from the base game insomuch that the hack can be considered an entirely different game, then yes, a unique set is usually acceptable. Linking these to the base set is not recommended since they will likely break the set.
   - Examples include [Metroid - Rogue Dawn](http://retroachievements.org/Game/9597), [Castlevania: The Holy Relics](http://retroachievements.org/game/11655), [Super Mario 64: Last Impact](http://retroachievements.org/game/12733), and [Super Metroid: Redesign](http://retroachievements.org/game/820).
 - If the hack does not have enough differences from the base game, but there are good achievement ideas exclusive to the hack, then consider doing a compilation of hacks or incorporating them into a bonus set.
-- Approval from Developer Compliance must be sought if a difficulty or story hack that bears close resemblence to the primary game is being considered for its own set.
+- Approval from Developer Compliance must be sought if a difficulty or story hack that bears close resemblance to the primary game is being considered for its own set.
 
 ## Bug-fix, Re-balancing and Utility Hacks
 
 - Hacks that include development-level integrated utilities such as easily accessible level select, debug menus, menus that display information or provide testing features not normally accessible via the normal game, are **almost** never allowed to be linked to core sets or get their own set.
   - Example: [Metroid + Saving](http://www.romhacking.net/hacks/1186/) for [Metroid](https://retroachievements.org/game/1487)
-- Hacks that offer gameplay utilities where it doesn't exist in the release version are **allowed at the discretion of the active developer (or revision vote if the developer is inactive)**. Utilities such as easy weapon select, in game maps, new minor upgrades or abilities, improved controls, faster movement.
+- Hacks that offer gameplay utilities where it doesn't exist in the release version are **allowed at the discretion of the active developer (or revision vote if the developer is inactive)**. Utilities such as easy weapon select, in-game maps, new minor upgrades or abilities, improved controls, faster movement.
   - Example: [Castlevania 2: Improved Controls](https://www.romhacking.net/hacks/4150/) for [Castlevania 2: Simon's Quest](https://retroachievements.org/game/1461)
 - Utilities and bug-fix hacks that improve or patch glitches found in the released version of games are **allowed at the discretion of the active developer (or revision vote if the developer is inactive)**.
   - Example: [Sonic 1 Bugfix](https://www.romhacking.net/hacks/3200/) for [Sonic the Hedgehog](http://retroachievements.org/game/1)

--- a/docs/guidelines/content/achievements-for-rom-hacks.md
+++ b/docs/guidelines/content/achievements-for-rom-hacks.md
@@ -4,6 +4,10 @@ RetroAchievements opens the doorway to include fun hack sets for players to enjo
 
 [[toc]]
 
+## Quality Assurance Team Approval Requirements
+
+Any hack or patch intended to be linked to a primary achievement set by anyone other than the original set developer requires approval from the Quality Assurance team in accordance with the [Adding Hashes document](/guidelines/content/adding-hashes.html) to ensure the appropriate compatibility testing process is followed.
+
 ## Game Trainer Patches
 
 - These are hacks that have integrated cheat features. For those familiar with GoodTool's naming scheme, ROMs with `[t1]`, `[t2]`, etc. in the title are examples of this.
@@ -14,17 +18,18 @@ RetroAchievements opens the doorway to include fun hack sets for players to enjo
 - If a hack has sufficient enough differences from the base game insomuch that the hack can be considered an entirely different game, then yes, a unique set is usually acceptable. Linking these to the base set is not recommended since they will likely break the set.
   - Examples include [Metroid - Rogue Dawn](http://retroachievements.org/Game/9597), [Castlevania: The Holy Relics](http://retroachievements.org/game/11655), [Super Mario 64: Last Impact](http://retroachievements.org/game/12733), and [Super Metroid: Redesign](http://retroachievements.org/game/820).
 - If the hack does not have enough differences from the base game, but there are good achievement ideas exclusive to the hack, then consider doing a compilation of hacks or incorporating them into a bonus set.
+- Approval from Developer Compliance must be sought if a difficulty or story hack that bears close resemblence to the primary game is being considered for its own set.
 
 ## Bug-fix, Re-balancing and Utility Hacks
 
 - Hacks that include development-level integrated utilities such as easily accessible level select, debug menus, menus that display information or provide testing features not normally accessible via the normal game, are **almost** never allowed to be linked to core sets or get their own set.
   - Example: [Metroid + Saving](http://www.romhacking.net/hacks/1186/) for [Metroid](https://retroachievements.org/game/1487)
-- Hacks that offer gameplay utilities where it doesn't exist in the release version are **allowed at the discretion of the active developer (or Revision vote if the developer is inactive)**. Utilities such as easy weapon select, in game maps, new minor upgrades or abilities, improved controls, faster movement.
+- Hacks that offer gameplay utilities where it doesn't exist in the release version are **allowed at the discretion of the active developer (or revision vote if the developer is inactive)**. Utilities such as easy weapon select, in game maps, new minor upgrades or abilities, improved controls, faster movement.
   - Example: [Castlevania 2: Improved Controls](https://www.romhacking.net/hacks/4150/) for [Castlevania 2: Simon's Quest](https://retroachievements.org/game/1461)
-- Utilities and bug-fix hacks that improve or patch glitches found in the released version of games are **allowed at the discretion of the active developer (or Revision vote if the developer is inactive)**.
+- Utilities and bug-fix hacks that improve or patch glitches found in the released version of games are **allowed at the discretion of the active developer (or revision vote if the developer is inactive)**.
   - Example: [Sonic 1 Bugfix](https://www.romhacking.net/hacks/3200/) for [Sonic the Hedgehog](http://retroachievements.org/game/1)
   - Example: [Double Dragon III - Difficulty Fix](https://www.romhacking.net/hacks/239/) for [Double Dragon III - The Sacred Stones](https://retroachievements.org/game/1662)
-- Cosmetic bug fixes which don't alter gameplay **might be allowed**, see [cosmetic/sprite hacks](#cosmetic--sprite-hacks).
+- Cosmetic bug fixes which don't alter gameplay **may be allowed in some circumstances**, see [cosmetic/sprite hacks](#cosmetic--sprite-hacks).
 
 ## Beta Release, Prototype and "Testing" Hacks
 
@@ -42,11 +47,7 @@ Examples:
 
 **Usually allowed**
 
-English is the Primary language of RetroAchievements. Translation Patches are sometimes applied by developers to non-English titles as the main MD5 for an achievement set where no licenced English version exists. In these cases patching instructions will be provided in the forum thread of that title. Providing an up-to-spec translation patch for an existing title is **usually allowed** to make a game more accessible to other native language speakers. You must deep-memory inspect your translation contribution against the core set and submit it for approval before handing it over to the developer of the set for posting in their thread along with the game.
-
-Sometimes translation patches may critically differ from the developer MD5 in memory differences that you may find online. Before linking these patches check with the original developer or do deep memory tests to ensure total compatibility. You can link translation patches you find online to core sets as long as the game's core achievements all function correctly and do not make the game more or less difficult.
-
-**Tip:** For games with text-triggered achievements (especially RPGs) it's recommend to find an event flag instead of hooking onto text or text ID. Text presentation varies between regional versions making multi-region support difficult.
+Translation patches may offer a significant player experience improvement and generally do not alter memory in the regions which achievements tend to evaluate.
 
 Examples:
 
@@ -58,14 +59,10 @@ Examples:
 
 **Usually allowed**
 
-- Cosmetic / Sprite hacks that do nothing to change the original game other than its graphics are **not allowed to become their own set**. They may be a little fun experience but they are still the same game. When linked they will be linked to the primary set.
+- Cosmetic / Sprite hacks that do nothing to change the original game other than its graphics are **not allowed to become their own set**. They may be considered for addition to a primary set as long as they are still the same core game. When linked they are required to be linked to the primary set.
 
 Examples:
 
 - [Castlevania - High Budget Remake](https://www.romhacking.net/hacks/2673/) for [Castlevania (NES)](http://retroachievements.org/game/1462)
 - [Super Waluigi 64](https://hacks.sm64hacks.com/hack/403) for [Super Mario 64](http://retroachievements.org/Game/10003)
 - [Chrono Trigger MSU-1 (with FMV's)](https://www.romhacking.net/forum/index.php?topic=23115.0) for [Chrono Trigger](http://retroachievements.org/game/319)
-
-## Consultation
-
-Consult the community via the forum and Discord for review and approval. You can get a good view-port of what the community likes to see by asking. Asking for **approval** before linking is an **integral** Developer practice, and falls within your code of conduct as a developer here at RetroAchievements.

--- a/docs/guidelines/content/adding-hashes.md
+++ b/docs/guidelines/content/adding-hashes.md
@@ -1,0 +1,50 @@
+---
+title: Adding Hashes
+description: Describes the process for adding hashes to primary achievement sets on RetroAchievements.
+---
+
+# Additional Hashes
+
+Adding hashes to a set can allow for a more enjoyable experience for players by adding translations, graphic improvements, or more regional support, however, this comes with risks that must be understood and properly mitigated. This document will explain the requirements for adding hashes to primary achievement sets.
+
+[[toc]]
+
+## Approval Process
+Approval from QA is required to add a hash to a set that contains any achievements which were not authored by the hash-adding developer. Contact the QATeam site account with plan details for approval consideration.
+
+## Restrictions
+If a set has any active authors, as set maintainers, only they may add additional hashes to the set.
+
+## Logic Back Up, Code Note Requirements, and Tickets
+If approved, hash-adding developer must back up all logic that is changed in the set’s official forum topic.  All code notes must be updated to specify for which hashes they pertain.  Any tickets that are created after a hash has been added are the sole responsibility of the hash-adding developer and subject to Developer Code of Conduct maintenance requirements.
+
+## Testing Requirements
+Different types of hashes require different levels of compatibility testing and rigor.  Stability is more important than compatibility and will be prioritized as such.  The following procedures are mandatory when adding additional hashes.
+
+### Translation or Graphical Patches for Already Supported Hashes:
+
+- Ensure all addresses used in existing logic are consistent with addresses in the translation hash.
+- Check every achievement, leaderboard and RP for any use of text based or sprite based addresses.  If found, must play through the new hash to the point where the text based or sprite based addresses are used for logic, verify the values and update appropriate logic and code notes.
+- In most cases, translation patches for supported sets are compatible without any logic changes.
+- Set shall be added to appropriate translation hubs.
+
+### Different Versions of Already Support Regional Hashes:
+
+- New versions must not contain differences that make achievements significantly easier than they were intended to be.  For questions, consult Developer Compliance.
+- Ensure all addresses used in existing logic are consistent with addresses in the new version hash.
+- Post a synopsis in the official forum of what the differences between versions are and play through all parts of the new version to test all existing logic in sections of the game that were changed in the new version.
+
+
+### Different Regional Format Hashes:
+
+- Validate addresses for all used logic in new regional patch.  Addresses may simply be offset by a particular distance.  That distance may or may not be consistent through all memory.  Each used address must be validated.
+- Individual address values, most commonly IDs or sprite animations may differ between regions.  All address values used in logic that reference a potential ID address must be validated in the new hash.
+- Achievements and leaderboards that use frames as timers must have additional logic added to account for frame rate differences between PAL and NTSC.  https://docs.retroachievements.org/Leaderboards/#value-format
+
+### Other Types of Hashes:
+
+Contact the QATeam site account with for guidance.
+
+## Reverting In Case of Issues
+
+QA may direct hash adding developer to restore the set to its original state if unresolved compatibility issues are introduced by a new hash.  The hash adding developer will given a time frame in which they must revert the set.

--- a/docs/guidelines/content/adding-hashes.md
+++ b/docs/guidelines/content/adding-hashes.md
@@ -13,10 +13,10 @@ Adding hashes to a set can allow for a more enjoyable experience for players by 
 Approval from QA is required to add a hash to a set that contains any achievements which were not authored by the hash-adding developer. Contact the QATeam site account with plan details for approval consideration.
 
 ## Restrictions
-If a set has any active authors, as set maintainers, only they may add additional hashes to the set.
+If a set has any active authors, only they, as set maintainers, may add additional hashes to the set.
 
 ## Logic Back Up, Code Note Requirements, and Tickets
-If approved, hash-adding developer must back up all logic that is changed in the set’s official forum topic.  All code notes must be updated to specify for which hashes they pertain.  Any tickets that are created after a hash has been added are the sole responsibility of the hash-adding developer and subject to Developer Code of Conduct maintenance requirements.
+If approved, the hash-adding developer must back up all logic that is changed in the set’s official forum topic.  All code notes must be updated to specify for which hashes they pertain.  Any tickets that are created after a hash has been added are the sole responsibility of the hash-adding developer and subject to Developer Code of Conduct maintenance requirements.
 
 ## Testing Requirements
 Different types of hashes require different levels of compatibility testing and rigor.  Stability is more important than compatibility and will be prioritized as such.  The following procedures are mandatory when adding additional hashes.


### PR DESCRIPTION
Adds new doc specifying process for adding additional hashes to primary sets.  Updates Hack doc to align with new procedures.