### PR TITLE
update: jr-dev hack limit changed to 1

### DIFF
--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -41,7 +41,7 @@ The following rules apply to all Junior Developers:
 - May only create a subset for games where the Junior Developer is the sole author
   - Must make a subset request in ⁠#jr-dev-forum which includes a set plan. If approved, the subset is subject to [Subset Rules](/guidelines/content/subsets)
     - May request to create a subset in addition to a primary claim if both are for the same game
-- May make a maximum of 2 sets for hacks during the program
+- May make a maximum of 1 set for a hack during the program
 
 ### Ticket Handling
 Junior Developers are expected to prioritize resolving open tickets over development of a new set.


### PR DESCRIPTION
Per CR team discussion/vote and QA/DC concurrence, jr-devs may now only produce 1 hack set while in the program.  Hack sets are typically very easy to copy logic/code notes from the base set and do not generally move jr-devs closer to graduation.  This change was made to further focus the jr-dev program on producing graduated developers using CR time as efficiently as possible.