### PR TITLE
Remove Stale Recommended Achievement Set Item

### DIFF
--- a/docs/guidelines/content/achievement-set-requirements.md
+++ b/docs/guidelines/content/achievement-set-requirements.md
@@ -43,7 +43,6 @@ description: This guide outlines the essential requirements for creating and sub
 
 ## Recommended but Not Required
 
-- Basic [Rich Presence](/developer-docs/rich-presence).
 - Leaderboards for scores and time challenges.
 - Adding the Missable Type to applicable achievements, especially for RPGs and long games.
   - Avoid overuse. If most of an achievement set is marked as missable, the mark becomes meaningless for that set.


### PR DESCRIPTION
Dynamic RP is required now, but the 'Recommended, but not required' item of 'Basic RP' was accidentally left in the document.