### PR TITLE
Add GameCube and PSP restrictions to Jr Dev policy

### DIFF
--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -46,7 +46,8 @@ The following rules apply to all Junior Developers:
 - Not eligible to participate in collaborations
 - May only [revise](/guidelines/content/achievement-set-revisions) sets where the Junior Developer is the sole author of the existing set.
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
-- May not make a claim without Code Reviewer approval on a Dreamcast set using the [Windows CE firmware](https://retroachievements.org/game/24833), PlayStation 2, or future 6th+ generation consoles at the discretion of the Code Review team
+- May not make a claim on any GameCube set
+- May not make a claim without Code Reviewer approval on sets for PlayStation 2, PlayStation Portable, future 6th+ generation consoles, or a Dreamcast set using the [Windows CE firmware](https://retroachievements.org/game/24833) at the discretion of the Code Review team
   - Must make a development request in #jr-dev-forum after at least 1 set has been published
 - May only create a subset for games where the Junior Developer is the sole author
   - Must make a subset request in ⁠#jr-dev-forum which includes a set plan. If approved, the subset is subject to [Subset Rules](/guidelines/content/subsets)

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -47,8 +47,11 @@ The following rules apply to all Junior Developers:
 - May only [revise](/guidelines/content/achievement-set-revisions) sets where the Junior Developer is the sole author of the existing set.
   - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
 - May not make a claim on any GameCube set
-- May not make a claim without Code Reviewer approval on sets for PlayStation 2, PlayStation Portable, future 6th+ generation consoles, or a Dreamcast set using the [Windows CE firmware](https://retroachievements.org/game/24833) at the discretion of the Code Review team
-  - Must make a development request in #jr-dev-forum after at least 1 set has been published
+- May not make a claim without Code Reviewer approval on sets for the below consoles. Junior Developers must make a development request in #jr-dev-forum after at least 1 set has been published, with approval at the discretion of the Code Reviewer team
+  - PlayStation 2
+  - PlayStation Portable
+  - Any future 6th+ generation consoles, unless specifically allowed
+  - Dreamcast games using the [Windows CE firmware](https://retroachievements.org/game/24833)
 - May only create a subset for games where the Junior Developer is the sole author
   - Must make a subset request in ⁠#jr-dev-forum which includes a set plan. If approved, the subset is subject to [Subset Rules](/guidelines/content/subsets)
     - May request to create a subset in addition to a primary claim if both are for the same game


### PR DESCRIPTION
[Discord link for PSP policy](https://discord.com/channels/310192285306454017/386068797921951755/1320524125738893402)

[Discord link for GameCube policy](https://discord.com/channels/310192285306454017/386068797921951755/1298759365611753543)

Also reworded the approval line to list PS2 and PSP first because they're significantly more relevant than Dreamcast CE, and are less likely to be missed this way.