### PR TITLE
Update doc: Add ticket lifeline to ticket doc

### DIFF
--- a/docs/guidelines/developers/handling-tickets.md
+++ b/docs/guidelines/developers/handling-tickets.md
@@ -7,6 +7,9 @@ description: Guidelines for managing and resolving achievement tickets, includin
 
 [[toc]]
 
+## Ticket Lifelines
+If you cannot figure out how to resolve a logic problem associated with a ticket, please seek assistance in the discord channel `#devs-help-me` first. There are many developers willing to help! If you still are having difficulty, you may also reach out directly to [QATeam](https://retroachievements.org/messages/create?to=QATeam) and ask for assistance. They will be glad to assist in troubleshooting.
+
 ## Handling Own Tickets
 
 **After a developer has published achievements, they should be prepared for bug reports.**

--- a/docs/guidelines/developers/handling-tickets.md
+++ b/docs/guidelines/developers/handling-tickets.md
@@ -8,7 +8,7 @@ description: Guidelines for managing and resolving achievement tickets, includin
 [[toc]]
 
 ## Ticket Lifelines
-If you cannot figure out how to resolve a logic problem associated with a ticket, please seek assistance in the discord channel `#devs-help-me` first. There are many developers willing to help! If you still are having difficulty, you may also reach out directly to [QATeam](https://retroachievements.org/messages/create?to=QATeam) and ask for assistance. They will be glad to assist in troubleshooting.
+If you cannot figure out how to resolve a logic problem associated with a ticket, please seek assistance in the Discord channel `#devs-help-me` first. There are many developers willing to help! If you still are having difficulty, you may also reach out directly to [QATeam](https://retroachievements.org/messages/create?to=QATeam) and ask for assistance. They will be glad to assist in troubleshooting.
 
 ## Handling Own Tickets
 


### PR DESCRIPTION
Adds blurb about ways to seek help fixing tickets including new option to contact QA directly for assistance.