### PR TITLE
Update: add jr-dev set plan requirement clarity

### DIFF
--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -20,13 +20,13 @@ To join the Junior Developer Program, the following requirements must be met:
 - Request the Junior Developer role in #role-request channel in the General section of the RA Discord server
   - Include your RA profile link
   - State the game for which you intend to create a set and link its RA set page or request that it be made if it does not exist
-  - Read through all [RetroAchievements Developer Docs](/developer-docs/) and fill out and post a [Set Design Plan](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
+  - Read through all [RetroAchievements Developer Docs](/developer-docs/) and fill out and post a [Set Plan](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0)
   - Ping the **@Code-Reviewer** role in your request to join thread
 - Unless specifically authorized by [Developer Compliance](https://retroachievements.org/messages/create?to=DevCompliance), all requirements in this section must be met to gain entry to the Junior Developer Program regardless of previous RA experience
 
 ### Claiming and Developing Sets
 
-Junior Developers must submit set plans for review immediately after making a claim. Junior Developers shall post a Set Plan Review in the #⁠jr-dev-forum, outlining the scope of the planned achievement set. The set plan is not a final product, however it must show a general outline of the planned set including progression, challenge, and other types of achievements. Brief descriptions and point values must be included as well. If during development significant deviations are made from the set plan, a revised set plan must be submitted for approval prior to requesting entry into the backlog.
+Junior Developers must submit set plans for review immediately after making a claim using a [Set Plan template](https://docs.google.com/spreadsheets/d/1VC2phJ9AUcZK5Ll4bVuMpJXED8QdM_nw8OdSAuLc3bI/edit#gid=0) or similar custom sheet. A post with only a textual description is not sufficient for a set plan. Junior Developers shall post a Set Plan Review in the #⁠jr-dev-forum, outlining the scope of the planned achievement set. The set plan is not a final product, however it must show a general outline of the planned set including progression, challenge, and other types of achievements. Brief descriptions and point values must be included as well. If during development significant deviations are made from the set plan, a revised set plan must be submitted for approval prior to requesting entry into the backlog.
 
 The purpose of the Set Review is to ensure Junior Developers have a solid baseline plan from which to work and that it is free of [Unwelcome Concepts](/guidelines/content/unwelcome-concepts.html). This review will be quick, and should largely mirror a typical process for developing a good RA set, which should always start with coming up with a set plan. This will give Code Reviewers an opportunity to avoid having to later review progression-only sets that would need to be expanded, or bloated sets that would need to be trimmed, and will hopefully streamline the review process for everybody.
 


### PR DESCRIPTION
Adds requirement for jr-devs to use a set plan template/sheet to submit set plans, not just a textual description.