### PR TITLE
Explicitly mark DoubleCherryGB as an unsupported core

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -111,7 +111,8 @@ description: Information about unsupported emulators and cores for RetroAchievem
 
 ## Game Boy
 
-- ❓ libretro core: **DoubleCherryGB**
+- ❌ libretro core: **DoubleCherryGB**
+  - Does not expose all memory, some achievements will show up as unsupported
 - ❓ libretro core: **Emux GB**
 - ❓ libretro core: **fixGB**
 - ❓ libretro core: **SameBoy**

--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -121,7 +121,8 @@ description: Information about unsupported emulators and cores for RetroAchievem
 
 - ❌ Standalone emulator: **Pizza Boy GBC**
   - No longer being developed. Compatibility issues can cause problems with unlocks. Devs have no means to resolve issues.
-- ❓ libretro core: **DoubleCherryGB**
+- ❌ libretro core: **DoubleCherryGB**
+  - Does not expose all memory, some achievements will show up as unsupported
 - ❓ libretro core: **Emux GB**
 - ❓ libretro core: **fixGB**
 - ❓ libretro core: **SameBoy**


### PR DESCRIPTION
There have been multiple reports from players testing DoubleCherryGB that the core does not expose all of the memory needed for achievement sets:
https://discord.com/channels/310192285306454017/310195377993416714/1341790128137437185
https://discord.com/channels/310192285306454017/490333108621672448/1348740525565673605

This pull request will update the Unsupported Emulators and Cores page to move DoubleCherryGB from "Unknown" to "Unsupported" for Game Boy and Game Boy Color.