### PR TITLE
update: add flycast standalone

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -276,6 +276,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 
 - ✅ libretro core: **Flycast**
   - Disable threaded rendering to properly use save states.
+- ✅ Standalone emulator: **[Flycast](https://github.com/flyinghead/flycast)**
 
 ### Sega Genesis/Mega Drive
 


### PR DESCRIPTION
` * Flycast: Nightly builds newer than 22 Jan are supported`
ref: https://retroachievements.org/viewtopic.php?t=29231&c=256525#256525

---

i think it's just better to link the github, instead of "CI builds" [page](https://flyinghead.github.io/flycast-builds/).
