### PR TITLE
Update support for Gearcoleco and Gearsystem (Colecovision / SG-1000)

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -83,8 +83,6 @@ description: Information about unsupported emulators and cores for RetroAchievem
 
 ## ColecoVision
 
-- ❌ libretro core: **Gearcoleco**
-
 ## Elektronika BK-0010/0011
 
 - ❌ _Not supported_
@@ -315,9 +313,6 @@ description: Information about unsupported emulators and cores for RetroAchievem
 - ❓ libretro core: **YabaSanshiro**
 
 ## SG-1000
-
-- ❌ libretro core: **Gearsystem**
-  - Has significant unexposed memory
 
 ## Sharp X1
 

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -78,6 +78,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 - ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
 - ✅ libretro core: **blueMSX**
 - ✅ BizHawk core: **ColecoHawk**
+- ✅ libretro core: **Gearcoleco**
 
 ### Elektor TV Games Computer
 
@@ -311,6 +312,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
   - Most recommended.
 - ✅ libretro core: **blueMSX**
 - ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
+- ✅ libretro core: **Gearsystem**
 
 ### SNES/Super Famicom/Satellaview/Sufami Turbo
 


### PR DESCRIPTION
I'm the author for both Gearcoleco and Gearsystem emulators.

Just saw that they are listed here as not supported for Colecovision and SG-1000 respectively.

I'm not sure why. I developed both of them with RetroAchievements support in mind. I just checked again and I was able to trigger achievements for both platforms using RetroArch.

If I'm wrong just let me know what is needed in the emulator side, but the games I checked seem to work fine.