### PR TITLE
Add Parallel Release Set and Revision Rules

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -235,6 +235,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
           link: "/guidelines/content/player-compatibility-testing",
         },
         {
+          text: "Games With Parallel Releases",
+          link: "/guidelines/content/games-with-parallel-releases",
+        },
+        {
           text: "Achievements for ROM Hacks",
           link: "/guidelines/content/achievements-for-rom-hacks",
         },

--- a/docs/.vitepress/config/es.ts
+++ b/docs/.vitepress/config/es.ts
@@ -246,6 +246,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
         //  text: "Player Compatibility Testing",
         //  link: "/guidelines/content/player-compatibility-testing",
         // },
+        //{
+        //  text: "Games With Parallel Releases",
+        //  link: "/guidelines/content/games-with-parallel-releases",
+        //},
         {
           text: "Logros para ROM Hacks",
           link: "/es/guidelines/content/achievements-for-rom-hacks",

--- a/docs/.vitepress/config/pt.ts
+++ b/docs/.vitepress/config/pt.ts
@@ -247,6 +247,10 @@ function sidebarGuidelines(): DefaultTheme.SidebarItem[] {
     //       link: "/guidelines/content/player-compatibility-testing",
     //     },
     //     {
+    //       text: "Games With Parallel Releases",
+    //       link: "/guidelines/content/games-with-parallel-releases",
+    //     },
+    //     {
     //       text: "Conquistas para ROM Hacks",
     //       link: "/pt/guidelines/content/achievements-for-rom-hacks",
     //     },

--- a/docs/guidelines/content/achievement-set-revisions.md
+++ b/docs/guidelines/content/achievement-set-revisions.md
@@ -45,6 +45,10 @@ Any developer wanting to revise a set needs to:
 
 3. **Post the plan** in the game's forum topic. **NOTE**: Be as specific as possible. The community deserves a good understanding of your intent.
 
+::: danger Un-Merging Parallel Release Sets
+Games with parallel releases whose base sets are currently merged together (Example: *Pokémon Red Version | Pokemon Blue Version*) may be un-merged into separate sets, but doing so has additional requirements beyond a standard revision. Please see the full rules in the [Games With Parallel Releases](/guidelines/content/games-with-parallel-releases) document.
+:::
+
 4. **Start a Discussion** by creating a new post in `#revision-discussion-forum`.
    - Your post title should include the game name and console. Ex: "Revision proposal - Super Mario Bros. (NES)"
    

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -25,7 +25,7 @@ This policy only applies to licensed retail games. Other categories of games, su
 Unmerging shall be allowed if a game currently has a merged base set, under the following requirements:
 
 - The author(s) of the merged base set shall be given preference as to which version their work shall become.
-   - If no longer able to be contacted, use best judgement when presenting the unmerge plan, paying attention to any written record that may indicate preference.
+   - If no longer able to be contacted, use best judgment when presenting the unmerge plan, paying attention to any written record that may indicate preference.
 - Version-specific achievements in the merged base set shall be transferred with authorship intact to the other version upon unmerge.
 - The unmerge plan must be approved by the Developer Compliance team, with input from the QA-Maintainers team.
 - A satisfactory plan for how to handle unlocks for players that have earned the merged set achievements must be developed and approved.

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -17,7 +17,7 @@ This policy only applies to licensed retail games. Other categories of games, su
 
 - Each version shall have its own set.
 - Each version's set shall have a different author.
-- Each version's set shall vary from each other, especially having achievements that highlight the differences between each set.
+- Each version's set must be unique from the others, while still covering all content available, highlighting differences between games with unique and creative achievements.
 - Sets whose versions were merged into one base set before this policy entered effect may remain merged.
 
 ## Can We Un-Merge Existing Sets?

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -8,7 +8,7 @@ description: Guidelines for handling games with parallel releases on RetroAchiev
 Some games have multiple versions that were released simultaneously in-parallel and are designed to interact with each other but offer differing play experiences while remaining at their core the same game. Ex: Mainline Pokemon games.
 
 ::: tip Retail Games Only
-This policy only applies to retail games. Hacks with parallel releases shall not have separate sets unless there are significant differences, subject to approval by the Developer Compliance team.
+This policy only applies to licensed retail games. Other categories of games, such as hacks, shall not have separate sets for parallel releases unless there are significant differences, subject to approval by the Developer Compliance team.
 :::
 
 [[toc]]

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -5,7 +5,7 @@ description: Guidelines for handling games with parallel releases on RetroAchiev
 
 # Games with Parallel Releases
 
-Some games have multiple versions that were released simultaneously in-parallel and are designed to interact with each other but offer differing play experiences while remaining at their core the same game. Ex: Mainline Pokemon games.
+Some games have multiple versions that were released simultaneously in-parallel and are designed to interact with each other, remaining at their core the same game yet offering differing play experiences. Ex: Mainline Pokemon games.
 
 ::: tip Retail Games Only
 This policy only applies to licensed retail games. Other categories of games, such as hacks, shall not have separate sets for parallel releases unless there are significant differences, subject to approval by the Developer Compliance team.
@@ -16,7 +16,8 @@ This policy only applies to licensed retail games. Other categories of games, su
 ## What Sets Can They Have?
 
 - Each version shall have its own set.
-- Each version’s set shall have a different author.
+- Each version's set shall have a different author.
+- Each version's set shall vary from each other, especially having achievements that highlight the differences between each set.
 - Sets whose versions were merged into one base set before this policy entered effect may remain merged.
 
 ## Can We Un-Merge Existing Sets?

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -23,8 +23,9 @@ This policy only applies to licensed retail games. Other categories of games, su
 
 Unmerging shall be allowed if a game currently has a merged base set, under the following requirements:
 
-- The author of the merged base set shall be given preference as to which version their work shall become.
+- The author(s) of the merged base set shall be given preference as to which version their work shall become.
+   - If no longer able to be contacted, use best judgement when presenting the unmerge plan, paying attention to any written record that may indicate preference.
 - Version-specific achievements in the merged base set shall be transferred with authorship intact to the other version upon unmerge.
 - The unmerge plan must be approved by the Developer Compliance team, with input from the QA-Maintainers team.
 - A satisfactory plan for how to handle unlocks for players that have earned the merged set achievements must be developed and approved.
-- Must pass a revision vote.
+- Must pass a standard revision vote.

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -1,0 +1,30 @@
+---
+title: Games with Parallel Releases
+description: Guidelines for handling games with parallel releases on RetroAchievements, including how new achievement sets should be created and how current achievement sets should be revised.
+---
+
+# Games with Parallel Releases
+
+Some games have multiple versions that were released simultaneously in-parallel and are designed to interact with each other but offer differing play experiences while remaining at their core the same game. Ex: Mainline Pokemon games.
+
+::: tip Retail Games Only
+This policy only applies to retail games. Hacks with parallel releases shall not have separate sets unless there are significant differences, subject to approval by the Developer Compliance team.
+:::
+
+[[toc]]
+
+## What Sets Can They Have?
+
+- Each version shall have its own set.
+- Each version’s set shall have a different author.
+- Sets whose versions were merged into one core set before this policy entered effect may remain merged.
+
+## Can We Un-Merge Existing Sets?
+
+Unmerging shall be allowed if a game currently has a merged core set, under the following requirements:
+
+- The author of the merged core set shall be given preference as to which version their work shall become.
+- Version-specific achievements in the merged core set shall be transferred with authorship intact to the other version upon unmerge.
+- The unmerge plan must be approved by the Developer Compliance team, with input from the QA-Maintainers team.
+- A satisfactory plan for how to handle unlocks for players that have earned the merged set achievements must be developed and approved.
+- Must pass a revision vote.

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -17,14 +17,14 @@ This policy only applies to licensed retail games. Other categories of games, su
 
 - Each version shall have its own set.
 - Each version’s set shall have a different author.
-- Sets whose versions were merged into one core set before this policy entered effect may remain merged.
+- Sets whose versions were merged into one base set before this policy entered effect may remain merged.
 
 ## Can We Un-Merge Existing Sets?
 
-Unmerging shall be allowed if a game currently has a merged core set, under the following requirements:
+Unmerging shall be allowed if a game currently has a merged base set, under the following requirements:
 
-- The author of the merged core set shall be given preference as to which version their work shall become.
-- Version-specific achievements in the merged core set shall be transferred with authorship intact to the other version upon unmerge.
+- The author of the merged base set shall be given preference as to which version their work shall become.
+- Version-specific achievements in the merged base set shall be transferred with authorship intact to the other version upon unmerge.
 - The unmerge plan must be approved by the Developer Compliance team, with input from the QA-Maintainers team.
 - A satisfactory plan for how to handle unlocks for players that have earned the merged set achievements must be developed and approved.
 - Must pass a revision vote.

--- a/docs/guidelines/content/games-with-parallel-releases.md
+++ b/docs/guidelines/content/games-with-parallel-releases.md
@@ -5,7 +5,7 @@ description: Guidelines for handling games with parallel releases on RetroAchiev
 
 # Games with Parallel Releases
 
-Some games have multiple versions that were released simultaneously in-parallel and are designed to interact with each other, remaining at their core the same game yet offering differing play experiences. Ex: Mainline Pokemon games.
+Some games have multiple versions that were released simultaneously in parallel and are designed to interact with each other, remaining at their core the same game yet offering differing play experiences. Ex: Mainline Pokemon games.
 
 ::: tip Retail Games Only
 This policy only applies to licensed retail games. Other categories of games, such as hacks, shall not have separate sets for parallel releases unless there are significant differences, subject to approval by the Developer Compliance team.

--- a/docs/guidelines/developers/claims-system.md
+++ b/docs/guidelines/developers/claims-system.md
@@ -79,7 +79,7 @@ Each developer is allowed four primary claims. Junior developers are allowed one
 
 - It is recommended that you post a complete plan in the forum topic. When doing so, be open to suggestions; you can get excellent input and suggestions this way.
 
-## Special Cases
+## Additional Rules for Specific Types of Sets
 
 ### Hacks
 

--- a/docs/guidelines/developers/claims-system.md
+++ b/docs/guidelines/developers/claims-system.md
@@ -78,3 +78,19 @@ Each developer is allowed four primary claims. Junior developers are allowed one
 ## Important Notes
 
 - It is recommended that you post a complete plan in the forum topic. When doing so, be open to suggestions; you can get excellent input and suggestions this way.
+
+## Special Cases
+
+### Hacks
+
+Refer to the [Achievements for ROM Hacks](/guidelines/content/achievements-for-rom-hacks) document for full information.
+
+- May not make a set claim for a cosmetic hack; these can likely just be linked to the base set with proper testing.
+- May not make a set claim for a simple QOL hack that does not significantly change the gameplay.
+
+### Games with Parallel Releases
+
+Refer to the [Games With Parallel Releases](/guidelines/content/games-with-parallel-releases) document for full information.
+
+- You may not claim a merged set. Example: May not make a claim for *Pokémon Black Version | Pokemon White Version*. These releases must have separate sets.
+- You may not claim a parallel version of a game for which you've already made another set. Example: Cannot make a set for [Pokémon White](https://retroachievements.org/game/16211) if you have claim for or already made a set for [Pokémon Black](https://retroachievements.org/game/3887)


### PR DESCRIPTION
Details set development and revision rules for games that have parallel releases.  Rules are drafted as requiring separate sets and provide a pathway to un-merge existing merged sets.  These rules were drafted based on an earlier [developer discussion](https://discord.com/channels/310192285306454017/1126941494746550322/1126941504292802772) and polling.