### PR TITLE
Remove DeSmuME 2015 from supported Nintendo DS cores

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -208,8 +208,6 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 - Limited microphone support.
 - ✅ libretro core: **DeSmuME**
   - Does not emulate the DSi.
-- ✅ libretro core: **DeSmuME 2015**
-  - Does not emulate the DSi.
 - ✅ libretro core: **melonDS**
 - ✅ libretro core: **melonDS DS**
 - ✅ BizHawk core: **melonDS**


### PR DESCRIPTION
Removing this date locked version of the DeSmeME core.  This version was preferred by some players, despite being very out of date, due to better performance on some games.  The MelonDS DS core is up to date and generally performs better than the other DS cores.