### PR TITLE
Add DeSmuME 2015 to unsupported Nintendo DS cores

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -202,6 +202,7 @@ description: Information about unsupported emulators and cores for RetroAchievem
  
 ## Nintendo DS
 
+- ❌ libretro core: **DeSmuME 2015**
 
 ## Nintendo DSi
 


### PR DESCRIPTION
Removing this date locked version of the DeSmeME core.  This version was preferred by some players, despite being very out of date, due to better performance on some games.  The MelonDS DS core is up to date and generally performs better than the other DS cores.