### PR TITLE
fix: discord channel names

### DIFF
--- a/docs/developer-docs/am-i-ready-for-review.md
+++ b/docs/developer-docs/am-i-ready-for-review.md
@@ -9,11 +9,11 @@ description: Comprehensive guidelines for the Junior Developer Program, includin
 
 Now that you have submitted your set for review (or perhaps you are still trying to decide if you are ready to do so), you may be wondering what you can do while waiting or while deciding.
 
-Go through this list and check all your conditions to make sure you are doing these best practices and avoiding these common mistakes.  Please do all of this while you are waiting for your review to be picked up (or before submitting), making any changes necessary.  That way when your review is picked up, you’ll have far fewer issues to resolve and your review will be quicker.
+Go through this list and check all your conditions to make sure you are doing these best practices and avoiding these common mistakes. Please do all of this while you are waiting for your review to be picked up (or before submitting), making any changes necessary. That way when your review is picked up, you’ll have far fewer issues to resolve and your review will be quicker.
 
-Does this seem like a lot? Well, most developers are going to be doing these things as they develop achievements, or before they promote their set to core.  Tackle each part one at a time and go through it slowly. Feel free to ask us questions in `#jr-devs` about any of the topics if you have trouble with them.
+Does this seem like a lot? Well, most developers are going to be doing these things as they develop achievements, or before they promote their set to core. Tackle each part one at a time and go through it slowly. Feel free to ask us questions in `#jr-devs` about any of the topics if you have trouble with them.
 
-## Use the `#jr-dev-forum`
+## Use the `#jr-devs-requests`
 
 - All interaction with your set creation, approval, and maintenance should be handled by yourself or through Code-Reviewers through the forum.
 - Non-Code Reviewer developers may not demote/promote your work or resolve tickets for you.
@@ -23,7 +23,7 @@ Does this seem like a lot? Well, most developers are going to be doing these thi
 Read over the [Writing Policy](/guidelines/content/writing-policy) and be sure your titles, descriptions, and other written features are in compliance.
 
 ::: tip WRITING ASSISTANCE IS AVAILABLE
-Are grammar and capitalization not your strong suit? Having trouble coming up with a concise description? Hop by the `#writing-requests-forum` on discord and have them look over your achievements while you await your review. They’ll be happy to help you out.
+Are grammar and capitalization not your strong suit? Having trouble coming up with a concise description? Hop by the `#writing-requests` on discord and have them look over your achievements while you await your review. They’ll be happy to help you out.
 :::
 
 ## Do you have badges?
@@ -62,9 +62,9 @@ There are a variety of Genre, Subgenre, Publisher, Developer, Series, Language, 
 - If not, you will want to use at least one of each to gain basic RP skills.
 - Macros are used to turn address values into text based on the value of an address and are the basic building block of good dynamic RP.
 - Conditionals are used to display different kinds of RP display strings based on game context.
-   - The most simple is for when a user is on the title screen; you can use a conditional to display this; usually in-game data is invalid when on the title screen and can make it look odd.
-   - If a game has multiple gameplay modes, you might want to display completely different data per mode. Conditionals let you do this.
-   
+  - The most simple is for when a user is on the title screen; you can use a conditional to display this; usually in-game data is invalid when on the title screen and can make it look odd.
+  - If a game has multiple gameplay modes, you might want to display completely different data per mode. Conditionals let you do this.
+
 ### Have you tested your Rich Presence?
 
 Make sure you test it under all game contexts (menus, title, in-game, in different game modes, early game, late game) to see if it ever displays something odd.
@@ -74,27 +74,27 @@ Make sure you test it under all game contexts (menus, title, in-game, in differe
 Having a single address can make your achievement prone to false triggers, especially if an emulator initializes memory oddly, or if the memory has some flicker. As a result, we want to avoid overly simple logic.
 
 - **Always** have more than one condition. Find a valid game state to pair with logic, such as “In game” or “player has control” You want to make sure the player is actually at a point where the other conditions are valid.
-- If you have more than one condition, but only one address is being used, be wary of *"on to off"* transitions. `Delta < X` followed by `Mem >= X` is effectively going from "on to off" with X being treated as the threshold.
+- If you have more than one condition, but only one address is being used, be wary of _"on to off"_ transitions. `Delta < X` followed by `Mem >= X` is effectively going from "on to off" with X being treated as the threshold.
   - Find some other conditions to add to it to make these kinds of things more robust and ensure the player is actually in a good game state when they happen.
-  
+
 ## Are you using Stored Hits (Sometimes called Target Hits)? Do you have a way to Reset those stored hits?
 
 ### What Stored Hits Are and Are Not
 
 **Stored hits are**: when you specify a specific amount of hits on a condition (or chain) and the condition is not considered true until that target amount of hits has been reached.
 
-**Stored hits are not**: the rolling number of hits in the achievement editor that show up on conditions without a target.  Those are for tracking how many frames a condition has ever been true and are purely informative.
+**Stored hits are not**: the rolling number of hits in the achievement editor that show up on conditions without a target. Those are for tracking how many frames a condition has ever been true and are purely informative.
 
-- Stored hits must always have a way to be reset, such as when a challenge is failed, when a player is no longer on the relevant level, or the player suffers a game over.  Otherwise these hits may stick around and cause a false trigger in the wrong context.
+- Stored hits must always have a way to be reset, such as when a challenge is failed, when a player is no longer on the relevant level, or the player suffers a game over. Otherwise these hits may stick around and cause a false trigger in the wrong context.
 - **Solution**: Add a condition or chain of conditions (such as with And Next) marked with the Reset If flag. When the condition(s) are true, the stored hits will be cleared.
 
 ### Are you using the stored hits to help check when a value changes from one thing to another thing?
 
-This is a thing you see on old sets from when the toolkit was smaller.  This is almost always the wrong way to do this.
+This is a thing you see on old sets from when the toolkit was smaller. This is almost always the wrong way to do this.
 
 - **Solution**: Use the Delta flag!
   - Delta represents the value of an address on the previous frame.
-  - You can pair `Delta address = Value originalValue` in one condition, and `Mem address = Value newValue` in the next condition and that will catch the very moment the address changes from *originalValue* to *newValue.*
+  - You can pair `Delta address = Value originalValue` in one condition, and `Mem address = Value newValue` in the next condition and that will catch the very moment the address changes from _originalValue_ to _newValue._
   - See also: [Do I Really Need to Use Delta?](/developer-docs/why-delta)
 
 ### Are you using stored hits because you have several conditions you want to be true at the same time in order to trigger the achievement?
@@ -105,29 +105,28 @@ This is a thing you see on old sets from when the toolkit was smaller.  This is 
 
 ## Are You Using Reset If? Should You?
 
-Reset If is used to clear all stored (target) hits.  It is not needed and should not be used if you are not using hits. Reset If flags can affect emulator performance and so we don't want to have *"Unneeded Usage of Reset If."*
+Reset If is used to clear all stored (target) hits. It is not needed and should not be used if you are not using hits. Reset If flags can affect emulator performance and so we don't want to have _"Unneeded Usage of Reset If."_
 
 - Using Reset If when you do not have stored (target) makes it harder for the CR team to know if you understand how hits and resets are used.
 - If you do not have target hits, you must not use Reset If flags.
-   - Reset If in this case is used as a "stop the achievement from happening if this condition is met" check, but what you want is the equivalent "allow the achievement to happen if the opposite condition is true."
+  - Reset If in this case is used as a "stop the achievement from happening if this condition is met" check, but what you want is the equivalent "allow the achievement to happen if the opposite condition is true."
   - **Solution**: Change `Reset If Mem address = Value X` into `Mem address != X`. This is equivalent logic and will work the same way.
   - Other comparisons can be inverted similarly. > becomes <=, etc.
   - Do this always as a best practice. Avoid unneeded Reset If flags!
 - If you do have target hits, check to make sure you **are** using Resets to clear them under appropriate conditions.
 
-
 ## Are you using a Pause If condition where the Pause If condition has no target hits?
 
-Pause If is only used to stop target hits in other conditions from increasing. Pause If can affect emulator performance and so we don’t want to have *"Unneeded Usage of Pause If."*
+Pause If is only used to stop target hits in other conditions from increasing. Pause If can affect emulator performance and so we don’t want to have _"Unneeded Usage of Pause If."_
 
 ### Do you have any other conditions with target hits?
 
 - Using Pause If when you do not have stored (target) hits in other conditions makes it harder for the CR team to know if you understand how hits and resets are used.
 - If you do not have target hits, you must not use Pause If flags.
-   - Pause If in this case is used as a "stop the achievement from happening if this condition is met" check, but what you want is the equivalent "allow the achievement to happen if the opposite condition is true."
-   - **Solution**: Change `Pause If Mem address = Value X` into `Mem address != X`. This is equivalent logic and will work the same way.
-   - Other comparisons can be inverted similarly. > becomes <=, etc.
-   - Do this always as a best practice. Avoid unneeded Pause If flags.
+  - Pause If in this case is used as a "stop the achievement from happening if this condition is met" check, but what you want is the equivalent "allow the achievement to happen if the opposite condition is true."
+  - **Solution**: Change `Pause If Mem address = Value X` into `Mem address != X`. This is equivalent logic and will work the same way.
+  - Other comparisons can be inverted similarly. > becomes <=, etc.
+  - Do this always as a best practice. Avoid unneeded Pause If flags.
 - If you do have target hits, check to make sure that your Pause If conditions are being used to prevent stored hits from increasing.
 
 ### Is the Pause If part of a block of protection logic used in all your achievements?
@@ -135,18 +134,18 @@ Pause If is only used to stop target hits in other conditions from increasing. P
 You may be using Pause If in one of the following types of protection: save protection, cheat protection, demo protection, etc.
 
 - If some of the achievements do need the Pause If conditions to prevent hits from increasing, then it is okay to leave them in all achievements, for consistency ease of maintenance.
-   - If you do need to make a change, it can be applied consistently to all achievements.
-   - However, it is a good idea to consider removing the Pause If flags from achievements where they are not necessary, especially if the set suffers from performance issues in emulation.
+  - If you do need to make a change, it can be applied consistently to all achievements.
+  - However, it is a good idea to consider removing the Pause If flags from achievements where they are not necessary, especially if the set suffers from performance issues in emulation.
 - If no achievements use stored (target) hits, then you'll want to remove the Pause If flags.
-   - **Solution**: Change `Pause If Mem address = Value X` into `Mem address != X`. This is equivalent logic and will work the same way.
-   - Other comparisons can be inverted similarly. > becomes <=, etc.
+  - **Solution**: Change `Pause If Mem address = Value X` into `Mem address != X`. This is equivalent logic and will work the same way.
+  - Other comparisons can be inverted similarly. > becomes <=, etc.
 - If it is not part of a protection block, refer to the earlier parts of this section.
 
 ## Are you using a Pause Lock?
 
 ### What is a Pause Lock?
 
-A Pause Lock is a condition (or chain of conditions) where the Pause If line has a target amount of hits.  When this hit value is locked, the group (Core, Alt1, etc) will no longer increase any target hits and will never be true until the hits on the Pause If line are reset.
+A Pause Lock is a condition (or chain of conditions) where the Pause If line has a target amount of hits. When this hit value is locked, the group (Core, Alt1, etc) will no longer increase any target hits and will never be true until the hits on the Pause If line are reset.
 
 ### Do you have a way to Reset the Pause Lock?
 
@@ -158,7 +157,7 @@ A Pause Lock is a condition (or chain of conditions) where the Pause If line has
 2. Yes, I do have a way to Reset it, either with a Reset in another group (Core, Alt1, etc) or a Reset Next If before the Pause Lock.
    - Great! Make sure you’ve tested that it resets at the appropriate time.
 3. No, I do not have a way to Reset the Pause Lock.
-   - Uh oh! If you don’t reset the pause lock, the achievement will forever be unable to be earned unless the user resets the game using the console’s reset or unless they reload the game. That’s almost always bad, so we want to make sure we have a logical time to reset an achievement’s pause lock.  This might simply be on game over, or dying and restarting a level, or on the title screen.
+   - Uh oh! If you don’t reset the pause lock, the achievement will forever be unable to be earned unless the user resets the game using the console’s reset or unless they reload the game. That’s almost always bad, so we want to make sure we have a logical time to reset an achievement’s pause lock. This might simply be on game over, or dying and restarting a level, or on the title screen.
    - Solution A: Put a Reset If condition (or chain of condition) in an Alt group. If you have no alt groups, you can create a single alt (delete the extra second alt) and put it in there. That alt will always be true while your reset condition is unmet, so the achievement can still trigger as normal.
    - Solution B: Put a Reset Next If condition (or chain of conditions) immediately before your Pause Lock condition (or chain of conditions that ends in a Pause Lock). Reset Next If has a higher priority than the condition (or chain of conditions) and will reset that specific pause lock.
 
@@ -174,21 +173,21 @@ In most cases, cheat codes provide a benefit that makes achievements easier. And
 Strongly consider removing them by putting [VOID] at the start of their title. These almost always are poor designs for achievements and your code reviewer will suggest the same.
 
 - Exceptions: a cheat code that causes a cool effect.
-   - In these cases, you’ll want to have an achievement trigger off of the cool effect that happens during gameplay and not from entering the code itself.
-   - There’s a game boy batman game with a cheat code that causes Robin to appear in boss fights to heal you. A cool achievement was made for Robin doing this.
+  - In these cases, you’ll want to have an achievement trigger off of the cool effect that happens during gameplay and not from entering the code itself.
+  - There’s a game boy batman game with a cheat code that causes Robin to appear in boss fights to heal you. A cool achievement was made for Robin doing this.
 
 ## Does your game have save files or passwords? Make sure there's protection!
 
 - If so, have you tested that loading a save file (especially an end game save file) or loading from a password does not trigger any achievements?
-   1. Load up the game, then activate all achievements.
-   2. Load your save file or enter your password.
-   3. Does anything trigger?
+  1.  Load up the game, then activate all achievements.
+  2.  Load your save file or enter your password.
+  3.  Does anything trigger?
       - If yes, you’ll need to add code to block them from triggering on save load.
       - Make sure to test that they still pop normally
       - Generally, loading a save file or password should not lock someone out of earning achievements. We are only looking for the save load/password load to not cause achievements to trigger.
 - If there are save files, have you tested that your logic works with all save slots? That is a requirement for an achievement set.
-   - If not, do so now.
-   - If it does not work with all save slots, you will need to revise your logic so that it does so. Usually there is at least an "active save slot" address, and often the active save data gets copied to a common location. Either case should be handled.
+  - If not, do so now.
+  - If it does not work with all save slots, you will need to revise your logic so that it does so. Usually there is at least an "active save slot" address, and often the active save data gets copied to a common location. Either case should be handled.
 - If the system uses a save on a memory card, have you tested that your logic works if the player has no memory card "inserted" in the emulator?
 
 ## Do any conditions in your achievements rely on text being a specific value?
@@ -208,5 +207,5 @@ Always make sure your achievements can pop!
   - Often times you can freeze invincibility frames or other things to help test too
 - Always make sure your failure conditions (Reset If, Pause Locks, etc) only happen when you expect.
 - Try to approach your challenges and achievements from wrong directions and goofy actions. Players do all kinds of weird things. Maybe a player does something in a different order than usual. Maybe they shoot something you didn’t realize could be shot and the achievement fails unexpectedly.
-   - Basically: **Try to break your achievements.**
+  - Basically: **Try to break your achievements.**
 - Until your set is released, it is good to pick a few achievements a day and test them again. The more you test, the less issues there will be when the set goes live.

--- a/docs/developer-docs/developer-welcome.md
+++ b/docs/developer-docs/developer-welcome.md
@@ -5,7 +5,7 @@ description: Welcomes newly graduated developers, teaches how to upload a set, a
 
 # Welcome to the Dev Team!
 
-Now that you’re a developer, I'm sure the first thing you want to know is how you can upload your set and what other privileges are now open to you. You'll have plenty of fancy new features on the website, emulator, and Discord server, which we will go over here. 
+Now that you’re a developer, I'm sure the first thing you want to know is how you can upload your set and what other privileges are now open to you. You'll have plenty of fancy new features on the website, emulator, and Discord server, which we will go over here.
 
 Joining the team comes with **new responsibilities and inactivity criteria** so please take the time to review the [Developers Code of Conduct](/guidelines/developers/code-of-conduct) before continuing.
 
@@ -24,6 +24,7 @@ This page is used for editing release dates as well as **drag-and-drop reorderin
 The quickest and easiest way to upload your first set is through the management page of your set. From there you can mark the achievements you want to promote and then click “Promote selected” to promote them all in a few clicks!
 
 To get to this page, go to your game’s page:
+
 1. Click on Manage
 2. Scroll down until you see the list of achievements
 3. If you’d like, you can reorder them by clicking the Start Reordering button and then dragging-and-dropping the achievements
@@ -37,7 +38,7 @@ To get to this page, go to your game’s page:
 
 Now that your set is live, it is time to announce it to everyone if you are on Discord!
 
-We have a handy bot command that you can use to auto generate a template *as long as your set is in core*. Go to #bot-spam and type in “!gan [gameid]” where [gameid] is the id of your game. 
+We have a handy bot command that you can use to auto generate a template _as long as your set is in core_. Go to #bot-spam and type in “!gan [gameid]” where [gameid] is the id of your game.
 
 The pinned messages in #devs-chat have an alternate colored template that can be used as well.
 
@@ -61,11 +62,11 @@ For details on how to propose a revision, see [Achievement Set Revisions](/guide
 
 If you are considering requesting a re-author of the set, contact DevCompliance for approval. The re-author request should not be included in the revision proposal.
 
-If you want to transfer over the earners for some/all of the previous achievements then you will need to reach out to RAdmin or #admin-site-cleanup on Discord for assistance.
+If you want to transfer over the earners for some/all of the previous achievements then you will need to reach out to RAdmin or #cleanup-admin on Discord for assistance.
 
 The request would include the Game and a full list of achievement transfers in Old ID -> New ID format
 
-Example: 
+Example:
 
 https://retroachievements.org/game/990
 
@@ -85,7 +86,7 @@ You will now have a few new privileges in the RA emulators to take advantage of.
 
 The biggest new privilege is that you can now link new hashes to games by loading the game in an RA emulator and linking it.
 
-If creating a new page, select "New Title" and write an appropriate name in the text box. Check if there are any junk pages labeled "~Z~ No Hash" which can be recycled. 
+If creating a new page, select "New Title" and write an appropriate name in the text box. Check if there are any junk pages labeled "~Z~ No Hash" which can be recycled.
 
 ::: info
 Further reading:
@@ -125,7 +126,7 @@ Developers have the ability to add games to a Want to Develop list. Sets can be 
 
 #### Creating Forum Topics
 
-When you go to claim a set, you no longer need to create a forum topic separately. The Make Claim button will automatically create a forum topic for you if one does not exist. 
+When you go to claim a set, you no longer need to create a forum topic separately. The Make Claim button will automatically create a forum topic for you if one does not exist.
 
 Keep in mind that you should NOT create forum topics without a valid reason, such as claiming a set. Otherwise, you will be the only person (besides admins) who can edit the top post, which is usually where important information such as supported game files or set notes is placed.
 
@@ -133,10 +134,11 @@ Keep in mind that you should NOT create forum topics without a valid reason, suc
 
 You now have full access to the Dev dropdown menu.
 
-- **Manage Core/Unofficial Achievements**: Promotion/demotion, typing, and ordering of achievements. 
+- **Manage Core/Unofficial Achievements**: Promotion/demotion, typing, and ordering of achievements.
 
 - **Manage Leaderboards**: Resetting entries, ordering, and deletion of leaderboards
-    - Please read [Editing Leaderboards](/guidelines/content/editing-leaderboards) before making edits or resetting entries for leaderboards that are not your own.
+
+  - Please read [Editing Leaderboards](/guidelines/content/editing-leaderboards) before making edits or resetting entries for leaderboards that are not your own.
 
 - **Manage Hashes**: Editing hash labels, Editing RAPatches URLs, and unlinking hashes
 
@@ -160,9 +162,9 @@ You will now have access to a handful of new Discord channels
 
 - **#devs-chat**
 
-- **#devs-help-me**
+- **#devs-help**
 
-- **#tickets-cleanup**
+- **#ticket-discussion**
 
 - **#ratools**
 

--- a/docs/developer-docs/devjam.md
+++ b/docs/developer-docs/devjam.md
@@ -61,7 +61,7 @@ Check the links here for console-specific guidelines and info:
 |   04   | 2024-05-01 - 2024-08-31 |       [Arcade](/developer-docs/devjam/4-arcade)        |           33           |      80       |
 |   05   | 2024-09-01 - 2024-11-30 |    [PC-8001/PC-8801](/developer-docs/devjam/5-pc88)    |           25           |      40       |
 |   06   | 2024-12-01 - 2025-03-16 |      [Apple II](/developer-docs/devjam/6-appleii)      |           20           |      40       |
-|   07   | 2025-04-01 - 2025-06-30 |   [Sega CD/32X](/developer-docs/devjam/7-segacd-32x)   |           TBA          |      TBA      |
+|   07   | 2025-04-01 - 2025-06-30 |   [Sega CD/32X](/developer-docs/devjam/7-segacd-32x)   |          TBA           |      TBA      |
 
 ## Planned DevJams
 

--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -207,7 +207,9 @@ An English release is considered a game released in English in US, Canada, UK, o
 1. Set must have a fair share of the work done by each dev - For example, sets with extreme splits like 80%/20% would not allow credit.
 2. Must be a full set covering every aspect of the game.
 3. Each Dev must publish at least 20 achievements each.
-  - For compilations, this requirement is waived if you make a full set for one or more games in a compilation.
+
+- For compilations, this requirement is waived if you make a full set for one or more games in a compilation.
+
 4. Achievements must make sense, no fluff to fulfill requirement.
 
 ### 011 [The Genesis of RA](https://retroachievements.org/game/1280)
@@ -427,7 +429,7 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
 3. Misc Tasks: Update a set in order to remove it from the following QA Hubs. Doesn't stack with a Full Set Clearing.
    - [No Dynamic RP](https://retroachievements.org/game/3083)
    - [Player-Input RP](https://retroachievements.org/game/28506)
-   - [Single Save Support](https://retroachievements.org/game/28449) 
+   - [Single Save Support](https://retroachievements.org/game/28449)
 4. No collaboration allowed.
 5. This quest does not stack with other revision DevQuests. If a set would also be eligible to DQ2 or DQ13 those quests will take priority.
 6. Sets are subject to DevQuest team approval, along with a small plan on what the dust-off will be about. Sets already in the approved DQ22 list do not require approval, only notification.
@@ -451,7 +453,6 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
    - You can see this list on the `Quest23: Elligible Games Lists` sheet within the DevQuest Sheets document.
 6. You may swap lists with other participants. All participants must confirm the swap before it is performed. Muti-way swaps (three or more developers) are allowed. Swapping will reset your three-month respin timer.
 
-   
 ## Wheel Spin DevQuest Rules
 
 1. You may respin 3 months after you spin. This requires and consumes your respin token for that quest

--- a/docs/developer-docs/emulator-setup-for-developers.md
+++ b/docs/developer-docs/emulator-setup-for-developers.md
@@ -41,7 +41,7 @@ With DuckStation, the file may be named either `RA_Integration-x64.dll` or `RA_I
 
 ![RAIntegration in DuckStation folder](/public/duckstation-raintegration-folder.png)
 
-When you run the emulator for the first time, a setup wizard will guide you through various options, including enabling and logging into RetroAchievements. Otherwise, you can find these options under Tools -> Achievements. 
+When you run the emulator for the first time, a setup wizard will guide you through various options, including enabling and logging into RetroAchievements. Otherwise, you can find these options under Tools -> Achievements.
 
 ![Achievement settings in DuckStation](/public/duckstation-achievement-settings.png)
 

--- a/docs/developer-docs/how-to-become-an-achievement-developer.md
+++ b/docs/developer-docs/how-to-become-an-achievement-developer.md
@@ -19,7 +19,7 @@ Follow the [guidelines on the Developer's Code of Conduct](/guidelines/developer
 
 ## Planning your Achievement Set
 
-Once you find a game to work on you need to plan your Achievement Set. Before claiming a game on site, Junior Developers must submit a set plan for approval in the `#jr-dev-forum`. 
+Once you find a game to work on you need to plan your Achievement Set. Before claiming a game on site, Junior Developers must submit a set plan for approval in the `#jr-devs-requests`.
 
 Be sure you know enough about the game to make a good set. Check the GameFAQs, wikias, watch longplay videos and try to learn more about the game, its secrets and details.
 
@@ -31,9 +31,9 @@ It's recommended that you post your plans on the official game's forum topic, so
 
 ## Claiming a Game and Beginning Development
 
-Once a set plan has been approved by a Code Reviewer, Junior Developers may claim the game and begin development. To claim a game, it must have a forum topic. If it doesn't have one already, you can ask a Code Reviewer to make one in the `#jr-dev-forum` in our Discord server.
+Once a set plan has been approved by a Code Reviewer, Junior Developers may claim the game and begin development. To claim a game, it must have a forum topic. If it doesn't have one already, you can ask a Code Reviewer to make one in the `#jr-devs-requests` in our Discord server.
 
-We recommend developing your first achievement set with a game that has 10 or fewer set requests.  This allows you to focus on the learning process and refine your skills, as initial achievement sets often benefit from iteration.  A smaller audience also helps manage initial support requests, preventing a sudden influx of tickets.
+We recommend developing your first achievement set with a game that has 10 or fewer set requests. This allows you to focus on the learning process and refine your skills, as initial achievement sets often benefit from iteration. A smaller audience also helps manage initial support requests, preventing a sudden influx of tickets.
 
 ## Required Knowledge
 
@@ -50,6 +50,7 @@ Junior Developer program graduates must demonstrate proficiency in the following
 - Producing high quality, stable sets with limited supervision
 
 Helpful initial topics to study:
+
 - [Hexadecimal notation](/developer-docs/memory-inspector#decimal-binary-and-hexadecimal-notations)
 - [Mem/Delta relationships](/developer-docs/delta-values)
 - Various memory sizes
@@ -75,7 +76,7 @@ The [Real Examples](/developer-docs/real-examples) and [Achievement Templates](/
 
 ## Requesting a Code Review
 
-After creating the achievement set, publish it to Unofficial and then create a post in `#jr-dev-forum`. Follow all of the requirements for [requesting a Code Review.](/developer-docs/jr-dev-rules.html#code-review-requests)
+After creating the achievement set, publish it to Unofficial and then create a post in `#jr-devs-requests`. Follow all of the requirements for [requesting a Code Review.](/developer-docs/jr-dev-rules.html#code-review-requests)
 
 ## When Will I Be Promoted to Developer?
 
@@ -85,6 +86,6 @@ The Code Reviewer team will consider a Junior Developer for graduation largely b
 
 - Their ability to publish work that meets or exceeds the standards of the [Developer's Code of Conduct](/guidelines/developers/code-of-conduct)
 - The quality and complexity of their work
-    - High quality is defined as strong set design, writing, badges, code notes and achievement logic
+  - High quality is defined as strong set design, writing, badges, code notes and achievement logic
 - The time and thought they put into planning and working on achievements
 - Showing the will to use the Developer status with care and responsibility

--- a/docs/developer-docs/jr-dev-rules.md
+++ b/docs/developer-docs/jr-dev-rules.md
@@ -32,7 +32,7 @@ The purpose of the Set Review is to ensure Junior Developers have a solid baseli
 
 Once a set plan is approved, Junior Developers may begin work on set development.
 
-Note: New Junior Developers who had a set plan approved when requesting to join the Junior Developer may immediately begin work on the set once they are onboarded and have made a claim on the set for which their initial plan was approved. 
+Note: New Junior Developers who had a set plan approved when requesting to join the Junior Developer may immediately begin work on the set once they are onboarded and have made a claim on the set for which their initial plan was approved.
 
 ### Rules and Restrictions
 
@@ -45,25 +45,26 @@ The following rules apply to all Junior Developers:
 - Will prioritize resolving open tickets over development of a new set. For additional information on ticket handling, see [Ticket Handling](#ticket-handling), below.
 - Not eligible to participate in collaborations
 - May only [revise](/guidelines/content/achievement-set-revisions) sets where the Junior Developer is the sole author of the existing set.
-  - Must make a revision request in #jr-dev-forum detailing the revision plan. The Code Reviewer team will consider the request for approval
+  - Must make a revision request in #jr-devs-requests detailing the revision plan. The Code Reviewer team will consider the request for approval
 - May not make a claim on any GameCube set
-- May not make a claim without Code Reviewer approval on sets for the below consoles. Junior Developers must make a development request in #jr-dev-forum after at least 1 set has been published, with approval at the discretion of the Code Reviewer team
+- May not make a claim without Code Reviewer approval on sets for the below consoles. Junior Developers must make a development request in #jr-devs-requests after at least 1 set has been published, with approval at the discretion of the Code Reviewer team
   - PlayStation 2
   - PlayStation Portable
   - Any future 6th+ generation consoles, unless specifically allowed
   - Dreamcast games using the [Windows CE firmware](https://retroachievements.org/game/24833)
 - May only create a subset for games where the Junior Developer is the sole author
-  - Must make a subset request in ⁠#jr-dev-forum which includes a set plan. If approved, the subset is subject to [Subset Rules](/guidelines/content/subsets)
+  - Must make a subset request in ⁠#jr-devs-requests which includes a set plan. If approved, the subset is subject to [Subset Rules](/guidelines/content/subsets)
     - May request to create a subset in addition to a primary claim if both are for the same game
 - May make a maximum of 1 set for a hack during the program
 
 ### Ticket Handling
+
 Junior Developers are expected to prioritize resolving open tickets over development of a new set.
 
 - If a ticket is in Request status while waiting for information from the reporter, they may continue work on a new set, but must immediately reprioritize the ticket(s) once the reporter responds
-  - To put a ticket into Request status, ask the Code Reviewers, using the #jr-dev-forum, to transfer the ticket to the reporter after you have requested further information by asking the reporter using a comment on the ticket.
+  - To put a ticket into Request status, ask the Code Reviewers, using the #jr-devs-requests, to transfer the ticket to the reporter after you have requested further information by asking the reporter using a comment on the ticket.
 - Once you have fully addressed the ticket, leave a comment on the ticket describing what the cause of the issue was and what you did to resolve the issue.
-- Contact the Code Reviewers, using the #jr-dev-forum, to resolve ot close the ticket as appropriate after your comment has been made.
+- Contact the Code Reviewers, using the #jr-devs-requests, to resolve ot close the ticket as appropriate after your comment has been made.
 
 ### Code Review Requests
 

--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -199,7 +199,7 @@ description: Information about unsupported emulators and cores for RetroAchievem
 
 - ⌛ BizHawk core: **Mupen64Plus**
   - Testing (there are some graphical issues that can be fixed using the angrylion plugin)
- 
+
 ## Nintendo DS
 
 - ❌ libretro core: **DeSmuME 2015**
@@ -232,7 +232,6 @@ description: Information about unsupported emulators and cores for RetroAchievem
 - ❌ _Not supported_ - needs hashing method and memory map
 
 ## PC-8800
-
 
 ## PC-9800
 

--- a/docs/es/developer-docs/how-to-become-an-achievement-developer.md
+++ b/docs/es/developer-docs/how-to-become-an-achievement-developer.md
@@ -19,7 +19,7 @@ Estos requisitos también son una lista de verificación para los revisores de c
 Sigue las [directrices del código de conducta del desarrollador](/es/guidelines/developers/code-of-conduct#working-on-empty-sets) para encontrar un juego.
 Asegúrate de que el juego cumpla con las [reglas y restricciones (EN)](/developer-docs/jr-dev-rules#rules-and-restrictions) antes de trabajar en logros.
 Para reclamar un juego, debe tener un tema en el foro.
-Si no tiene uno, puedes pedir a un revisor de código que cree uno en el `#jr-dev-forum` en nuestro servidor de Discord.
+Si no tiene uno, puedes pedir a un revisor de código que cree uno en el `#jr-devs-requests` en nuestro servidor de Discord.
 Siéntete libre de declarar tus intenciones de trabajar en el juego en el tema, y publicar actualizaciones a medida que avanzas.
 
 **Consejo**: para tu primer set de logros se recomienda elegir un juego que aún no tenga logros **y** que no sea muy popular.
@@ -104,7 +104,7 @@ Para familiarizarte con estas técnicas, debes practicar. **Puedes usar cualquie
 
 ## Revise su trabajo
 
-Después de haber creado varios logros, súbelos a Unofficial y luego crea una publicación en `#jr-dev-forum` en nuestro servidor de Discord (si no usas Discord, envía un mensaje a [RAdmin](http://retroachievements.org/user/RAdmin)) y pide que alguien revise tu trabajo.
+Después de haber creado varios logros, súbelos a Unofficial y luego crea una publicación en `#jr-devs-requests` en nuestro servidor de Discord (si no usas Discord, envía un mensaje a [RAdmin](http://retroachievements.org/user/RAdmin)) y pide que alguien revise tu trabajo.
 
 **NO** pidas a otro desarrollador que promueva tus logros a Core sin una revisión adecuada.
 

--- a/docs/es/general/faq.md
+++ b/docs/es/general/faq.md
@@ -121,7 +121,7 @@ El hash de RA es una cadena única de 32 números hexadecimales, para distinguir
 
 ### ¿Cómo solicito un desbloqueo manual?
 
-- Si usas [Discord](https://discord.gg/dq2E4hE), escribe una solicitud en el canal [#manual-unlock (desbloqueo manual)](https://discord.com/channels/310192285306454017/1029858289221116104) siguiendo el formato que hay en el [mensaje fijado de este hilo](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966).
+- Si usas [Discord](https://discord.gg/dq2E4hE), escribe una solicitud en el canal [#unlock-requests (desbloqueo manual)](https://discord.com/channels/310192285306454017/1029858289221116104) siguiendo el formato que hay en el [mensaje fijado de este hilo](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966).
 
 - Si no usas [Discord](https://discord.gg/dq2E4hE). Estando logueado en **RetroAchievements.org** [envía un mensaje privado](https://retroachievements.org/createmessage.php?t=RAdmin) al usuario [RAdmin](https://retroachievements.org/user/RAdmin) con el título: **Manual Unlock Request (Petición de desbloqueo manual)**
   y una descripción que sea similar a esta:
@@ -144,7 +144,7 @@ El hash de RA es una cadena única de 32 números hexadecimales, para distinguir
    1. Capturas de pantalla que muestren que se está jugando en HARDCORE y se ha completado el logro.
    2. **Video (aún mejor)** ([ejemplo perfecto de prueba proporcionada por gr1nya](https://youtu.be/uqD-GTkZbLo)).
    3. Ejemplos de logros que hayas conseguido que demuestren que has ganado el logro. Por ejemplo: Has conseguido el logro de 10 000 puntos, pero el de 5000 puntos no se te ha concedido.
-3. Si estás en nuestro servidor discord, envía un mensaje al canal de [#manual-unlock (desbloqueo manual)](https://discord.gg/FswPDnu) añadiendo **@manual-unlock**. Si no es el caso, [envía un mensaje privado](https://retroachievements.org/createmessage.php?t=RAdmin) al usuario [RAdmin](https://retroachievements.org/user/RAdmin). El mensaje debe contener:
+3. Si estás en nuestro servidor discord, envía un mensaje al canal de [#unlock-requests (desbloqueo manual)](https://discord.gg/FswPDnu) añadiendo **@manual-unlock**. Si no es el caso, [envía un mensaje privado](https://retroachievements.org/createmessage.php?t=RAdmin) al usuario [RAdmin](https://retroachievements.org/user/RAdmin). El mensaje debe contener:
    1. El enlace al ticket. Puedes encontrar el ticket aquí: http://retroachievements.org/ticketmanager.php
    2. En qué modo estabas jugando (HARDCORE/softcore)
    3. Enlace a la [prueba certificada](#qualified-proof) de completado. Incluye una prueba de que el logro se consiguió en HARDCORE, si estabas jugando en HARDCORE.

--- a/docs/general/contributing-to-the-docs.md
+++ b/docs/general/contributing-to-the-docs.md
@@ -241,9 +241,9 @@ Results:
 
 | First Header | Second Header | Third Header |
 | :----------- | :-----------: | -----------: |
-| Left         | Center        | Right        |
-| Left         | Center        | Right        |
-| Left         | Center        | Right        |
+| Left         |    Center     |        Right |
+| Left         |    Center     |        Right |
+| Left         |    Center     |        Right |
 
 ## VitePress Components
 

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -7,28 +7,28 @@ description: Explore current and past RetroAchievements events, from ongoing cha
 
 ## Current Events
 
-| Event Name                                  | Current Host(s) | Relevant Link                                                      | More Info                |
-| ------------------------------------------- | --------------- | ------------------------------------------------------------------ | ------------------------ |
-| Achievement of the Week                     | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24926) |                          |
-| AotW: Akira Toriyama Tribute                | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26722) |                          |
-| Bounty Hunters                              | s0uth           | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26501) |                          |
-| Challenge League                            | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24927) |                          |
-| [DevJam](/developer-docs/devjam)            | televandalist   | [Forum Topic](https://retroachievements.org/viewtopic.php?t=22368) | Developer Event          |
-| [DevQuests](/developer-docs/devquests)      | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=13060) | Developer Event (Series) |
-| Draw Your Pokemon                           | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=21011) |                          |
-| Evergreen Events                            | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25332) |                          |
-| Final Fantasy V Four Job Fiesta             | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26862) |                          |
-| House Cleaning                              | Falcus          | [Forum Topic](https://retroachievements.org/viewtopic.php?t=21939) |                          |
-| Leaderboard of the Month                    | drisc           | [Forum Topic](https://retroachievements.org/viewtopic.php?t=19693) |                          |
-| On the Horizon                              | AuburnRDM       | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25374) |                          |
-| Peak Streak                                 | Bendyhuman      | [Forum Topic](https://retroachievements.org/viewtopic.php?t=12108) |                          |
-| PlayJam                                     | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26319) |                          |
-| Rack It Up                                  | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24535) |                          |
-| RetroAchievements Roulette (RAWR)           | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25399) |                          |
-| [Rollouts](/developer-docs/rollouts)        |                 |                                                                    |                          |
-| Simple Monthly Master                       | JAM             | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25995) |                          |
-| The Unwanted                                | AuburnRDM       | [Forum Topic](https://retroachievements.org/viewtopic.php?t=14787) |                          |
-| VGM Contest                                 | Yunalle         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26700) |                          |
+| Event Name                             | Current Host(s) | Relevant Link                                                      | More Info                |
+| -------------------------------------- | --------------- | ------------------------------------------------------------------ | ------------------------ |
+| Achievement of the Week                | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24926) |                          |
+| AotW: Akira Toriyama Tribute           | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26722) |                          |
+| Bounty Hunters                         | s0uth           | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26501) |                          |
+| Challenge League                       | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24927) |                          |
+| [DevJam](/developer-docs/devjam)       | televandalist   | [Forum Topic](https://retroachievements.org/viewtopic.php?t=22368) | Developer Event          |
+| [DevQuests](/developer-docs/devquests) | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=13060) | Developer Event (Series) |
+| Draw Your Pokemon                      | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=21011) |                          |
+| Evergreen Events                       | Various         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25332) |                          |
+| Final Fantasy V Four Job Fiesta        | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26862) |                          |
+| House Cleaning                         | Falcus          | [Forum Topic](https://retroachievements.org/viewtopic.php?t=21939) |                          |
+| Leaderboard of the Month               | drisc           | [Forum Topic](https://retroachievements.org/viewtopic.php?t=19693) |                          |
+| On the Horizon                         | AuburnRDM       | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25374) |                          |
+| Peak Streak                            | Bendyhuman      | [Forum Topic](https://retroachievements.org/viewtopic.php?t=12108) |                          |
+| PlayJam                                | Sutarion        | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26319) |                          |
+| Rack It Up                             | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=24535) |                          |
+| RetroAchievements Roulette (RAWR)      | StingX2         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25399) |                          |
+| [Rollouts](/developer-docs/rollouts)   |                 |                                                                    |                          |
+| Simple Monthly Master                  | JAM             | [Forum Topic](https://retroachievements.org/viewtopic.php?t=25995) |                          |
+| The Unwanted                           | AuburnRDM       | [Forum Topic](https://retroachievements.org/viewtopic.php?t=14787) |                          |
+| VGM Contest                            | Yunalle         | [Forum Topic](https://retroachievements.org/viewtopic.php?t=26700) |                          |
 
 ## Past or Seasonal Events
 

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -122,38 +122,46 @@ RA hash is an unique string of 32 hexadecimal numbers, to distinguish different 
 ### How do I request a manual unlock?
 
 #### For Discord Users (Recommended Method):
-Post your request in the [#manual-unlock](https://discord.com/channels/310192285306454017/1029858289221116104) channel following the format in [this stickied thread](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966). This method allows for faster communication or updates when needed as well as easier ways to upload video and images for proof.
+
+Post your request in the [#unlock-requests](https://discord.com/channels/310192285306454017/1029858289221116104) channel following the format in [this stickied thread](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966). This method allows for faster communication or updates when needed as well as easier ways to upload video and images for proof.
 
 #### For Website Requests:
+
 There are two ways you can send the request through the website.
+
 - Directly send a message to the [RAdmin](https://retroachievements.org/user/RAdmin) user with the title: **Manual Unlock Request**
 - On an individual achievements page follow the `Report an issue` link and then click the `Request Manual Unlock` button which will automatically format a message to [RAdmin](https://retroachievements.org/user/RAdmin) for you to edit and send.
 
 When sending a manual unlock request via the website your message <ins>must</ins> include all of the following details. Requests missing any of these items will be automatically denied without any follow-up:
-1. Achievement Identification:
-   - Provide a direct link to the Achievement ID(s) of the unlock(s) you’re requesting. 
-     - If your request contains more than three achievements then please also include a list of just the IDs is comma delimited format, ex. `123, 456, 789`.
-    - State whether the request is for softcore or hardcore unlocks.
 
-2. Broken Achievement Ticket: 
+1. Achievement Identification:
+
+   - Provide a direct link to the Achievement ID(s) of the unlock(s) you’re requesting.
+     - If your request contains more than three achievements then please also include a list of just the IDs is comma delimited format, ex. `123, 456, 789`.
+   - State whether the request is for softcore or hardcore unlocks.
+
+2. Broken Achievement Ticket:
+
    - If the issue relates to a broken achievement, include a link to the ticket you have created.
      - Exception: If the achievement was triggered correctly in the emulator but did not sync to your profile due to a network issue, do not create a ticket. Instead, clearly state that a network issue is the culprit.
-     - Read [The Anatomy Of A Good Ticket](https://news.retroachievements.org/issues/2022-06/goodticket.html)  for a better idea of what makes tickets helpful.
+     - Read [The Anatomy Of A Good Ticket](https://news.retroachievements.org/issues/2022-06/goodticket.html) for a better idea of what makes tickets helpful.
 
-3. Proof of Completion:  
-   - General Proof Requirements:  
-     - Supply a direct, plain-text link (do not use website markdowns or embedded images) to your proof.  
-     - Use external hosting services (e.g., imgur, YouTube, or a cloud service) for screenshots or videos. Local file links or embedded images are not accepted.  
-   - Proof by Achievement Type:  
+3. Proof of Completion:
+
+   - General Proof Requirements:
+     - Supply a direct, plain-text link (do not use website markdowns or embedded images) to your proof.
+     - Use external hosting services (e.g., imgur, YouTube, or a cloud service) for screenshots or videos. Local file links or embedded images are not accepted.
+   - Proof by Achievement Type:
      - Progression Achievements: A link to another unlocked progression achievement later in the game is acceptable. Otherwise an appropriate screenshot will likely suffice.
-     - Challenge Achievements: Full video evidence is required from the start of the challenge to the end. Even if the achievement has a challenge icon showing, you must provide video proof. Evidence needs to capture the triggering moment, show the active challenge icon (or when it falsely disappears), and confirm that Hardcore mode was active if it is a Hardcore request.  
+     - Challenge Achievements: Full video evidence is required from the start of the challenge to the end. Even if the achievement has a challenge icon showing, you must provide video proof. Evidence needs to capture the triggering moment, show the active challenge icon (or when it falsely disappears), and confirm that Hardcore mode was active if it is a Hardcore request.
      - Other Achievements: A clear screenshot or a link to another related achievement (only possible if the requested achievement was already done) is usually sufficient. Use your best judgment if a video might be warranted.
      - Network Issues: A clear screenshot showing the achievement unlocked in your emulator is the best proof if you notice before closing your emulator. Otherwise the above types still apply.
 
-4. Link Verification:  
+4. Link Verification:
    - Before sending your request, use the Preview function to verify that all your links work correctly. We do not have the capacity to fix or follow up on broken/mis formatted links, and any invalid links will result in an immediate denial.
 
 #### A Few Important Reminders:
+
 - These guidelines are in place because we receive a high volume of manual unlock requests, and many are incomplete or improperly formatted. Missing or invalid information leads to denial without response.
 - Even if your submission meets all the requirements, the RA team reserves the right to deny the request if the provided proof is deemed insufficient.
 - Manual unlocks are intended for players with proof of earning achievements that did not trigger on site due to a bug or network issue. They are **not** intended for, and will not be awarded to players who have played the game prior to a set being available, or on an another inherently unsupported platform (original hardware for example), or before you started playing on RetroAchievements.
@@ -161,20 +169,22 @@ When sending a manual unlock request via the website your message <ins>must</ins
 
 #### In summary how to request a manual unlock
 
-1. **Open a Ticket (When Applicable):**  
-   - Report the issue by opening a ticket that clearly describes the problem with the achievement.  
+1. **Open a Ticket (When Applicable):**
+
+   - Report the issue by opening a ticket that clearly describes the problem with the achievement.
      - Note: If the achievement was triggered correctly except for a network sync issue, you do not need to open a ticket—just explain the network issue in your manual unlock request.
 
-2. **Gather Adequate Proof:**  
-   - Provide evidence that you met all the achievement requirements. Acceptable forms of proof include:  
-     - **Screenshots:** Showing you were playing in HARDCORE mode and that you met the achievement requirements.  
-     - **Videos:** Capture the critical moment when the achievement should trigger. (Especially necessary for challenge achievements and hardcore submissions.)  
+2. **Gather Adequate Proof:**
+
+   - Provide evidence that you met all the achievement requirements. Acceptable forms of proof include:
+     - **Screenshots:** Showing you were playing in HARDCORE mode and that you met the achievement requirements.
+     - **Videos:** Capture the critical moment when the achievement should trigger. (Especially necessary for challenge achievements and hardcore submissions.)
      - **Comparative Achievement Evidence:** For example, if you received a higher-tier achievement (such as a 10k points achievement) but missed out on a required lower-tier one (like 5k points).
 
-3. **Submit Your Request:**  
-   - **Discord Users:** Post a message in [#manual-unlock](https://discord.com/channels/310192285306454017/1029858289221116104) following [this stickied thread](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966)
+3. **Submit Your Request:**
+   - **Discord Users:** Post a message in [#unlock-requests](https://discord.com/channels/310192285306454017/1029858289221116104) following [this stickied thread](https://discord.com/channels/310192285306454017/1029858289221116104/threads/1029875838327463966)
    - **Website Users:** While signed into RetroAchievements.org, send a request to the RAdmin user with the required information listed above
-     
+
 ### What if I got an achievement I didn't earn?
 
 Same with not getting it when you should in most cases you'll want to [create a ticket report](#how-do-i-report-a-broken-achievement), leaving an explanation of what went wrong. You'll also want to reset these achievements from your earn history so you can get the satisfaction of truly earning them.

--- a/docs/general/standalone-support.md
+++ b/docs/general/standalone-support.md
@@ -14,7 +14,7 @@ We offer support for Standalone games, which do not use an emulator to connect t
 Standalone support for a game has strict non-negotiable requirements that must be met.
 
 - The proposer must either be a Developer on RetroAchievements, or a Junior Developer with at least one published set, as these achievement sets still have to follow our global [Achievement Design](https://docs.retroachievements.org/developer-docs/achievement-design.html) rules. This is not something we can trust anyone with who has not showed us their proficiency in set design before. Note that if you are a Junior Developer and your proposal gets accepted, that your Standalone project will **not** count towards graduation as it does not involve regular achievement development that you are graded on by Code Reviewers. Likewise, you are still expected to work towards graduation.
-   - Alternatively, the proposer may suggest a standalone without having developed a set, but must do so with the support of a RetroAchievements Developer who will be in charge of set design.
+  - Alternatively, the proposer may suggest a standalone without having developed a set, but must do so with the support of a RetroAchievements Developer who will be in charge of set design.
 - You must be able to enforce Hardcore restrictions as shown in the [Global Leaderboard and Achievement Hunting Rules](https://docs.retroachievements.org/guidelines/users/global-leaderboard-and-achievement-hunting-rules.html). Such examples include black/whitelisting other mods and/or cheats that reduce the challenge of achievements, or disallowing multiplayer to prevent unfair advantages. These advantages should only be reserved for Softcore players, if applicable.
 - We expect you to have knowledge of the tools required to add Standalone support to a game. This varies depending on the game you are working on, with some games requiring expertise with programming languages such as C#, while other games may require extensive modding tools available which can be leveraged for developing an achievement set.
 
@@ -23,7 +23,7 @@ Standalone support for a game has strict non-negotiable requirements that must b
 We will be listing some guidelines below as for what we are looking for. However, do keep in mind that at all times, **the Admin team of RetroAchievements makes the decision as to whether we want to proceed with your proposal.** A good plan- or prototype must therefore always be presented.
 
 - It is allowed to request Standalone support for games that already have achievement sets on other platforms, such as Steam.
-   - However, the set on RetroAchievements must be significantly different enough from the existing ones. Plagiarism from other platforms is not allowed, with our sets needing to offer a unique experience not present in the official sets.
+  - However, the set on RetroAchievements must be significantly different enough from the existing ones. Plagiarism from other platforms is not allowed, with our sets needing to offer a unique experience not present in the official sets.
 - Official support for MMO private servers must be proposed in collaboration with the host(s) of the server, as these will likely have to built within the code of the server, barring rare exceptions.
 - Fangames are allowed, but do beware that we will not be hosting these within our own community to prevent potential legality issues. You must ensure that the user has access to everything necessary without being reliant on our community.
 

--- a/docs/guidelines/developers/handling-tickets.md
+++ b/docs/guidelines/developers/handling-tickets.md
@@ -8,7 +8,7 @@ description: Guidelines for managing and resolving achievement tickets, includin
 [[toc]]
 
 ## Ticket Lifelines
-If you cannot figure out how to resolve a logic problem associated with a ticket, please seek assistance in the Discord channel `#devs-help-me` first. There are many developers willing to help! If you still are having difficulty, you may also reach out directly to [QATeam](https://retroachievements.org/messages/create?to=QATeam) and ask for assistance. They will be glad to assist in troubleshooting.
+If you cannot figure out how to resolve a logic problem associated with a ticket, please seek assistance in the Discord channel `#devs-help` first. There are many developers willing to help! If you still are having difficulty, you may also reach out directly to [QATeam](https://retroachievements.org/messages/create?to=QATeam) and ask for assistance. They will be glad to assist in troubleshooting.
 
 ## Handling Own Tickets
 

--- a/docs/pt/developer-docs/am-i-ready-for-review.md
+++ b/docs/pt/developer-docs/am-i-ready-for-review.md
@@ -13,7 +13,7 @@ Percorra esta lista e verifique todas as suas condições para garantir que voc�
 
 Parece muito? Bem, a maioria dos desenvolvedores vai fazer essas coisas enquanto desenvolve conquistas, ou antes de promover seu conjunto para o core. Aborde cada parte uma por vez e avance lentamente. Sinta-se à vontade para nos fazer perguntas no `#jr-devs` sobre qualquer um dos tópicos se tiver problemas com eles.
 
-## Use o `#jr-dev-forum`
+## Use o `#jr-devs-requests`
 
 - Toda interação com a criação, aprovação e manutenção do seu conjunto deve ser tratada por você mesmo ou através dos Revisores de Código no fórum.
 - Desenvolvedores que não são Revisores de Código não podem rebaixar/promover seu trabalho ou resolver tickets para você.
@@ -23,7 +23,7 @@ Parece muito? Bem, a maioria dos desenvolvedores vai fazer essas coisas enquanto
 Leia a [Política de Escrita](/guidelines/content/writing-policy) e certifique-se de que seus títulos, descrições e outros elementos escritos estejam em conformidade.
 
 ::: tip ASSISTÊNCIA DE ESCRITA ESTÁ DISPONÍVEL
-Gramática e capitalização não são seu forte? Tendo dificuldade para criar uma descrição concisa? Passe pelo `#writing-requests-forum` no Discord e peça para eles analisarem suas conquistas enquanto você aguarda sua revisão. Eles ficarão felizes em ajudar.
+Gramática e capitalização não são seu forte? Tendo dificuldade para criar uma descrição concisa? Passe pelo `#writing-requests` no Discord e peça para eles analisarem suas conquistas enquanto você aguarda sua revisão. Eles ficarão felizes em ajudar.
 :::
 
 ## Você tem badges?

--- a/docs/pt/developer-docs/developer-welcome.md
+++ b/docs/pt/developer-docs/developer-welcome.md
@@ -63,7 +63,7 @@ Para detalhes sobre como propor uma revisão, veja [Revisões de Conjuntos de Co
 
 Se você está considerando solicitar uma re-autoria do conjunto, entre em contato com DevCompliance para aprovação. A solicitação de re-autoria não deve ser incluída na proposta de revisão.
 
-Se você quiser transferir os conquistadores de algumas/todas as conquistas anteriores, precisará entrar em contato com RAdmin ou #admin-site-cleanup no Discord para assistência.
+Se você quiser transferir os conquistadores de algumas/todas as conquistas anteriores, precisará entrar em contato com RAdmin ou #cleanup-admin no Discord para assistência.
 
 A solicitação incluiria o Jogo e uma lista completa de transferências de conquistas no formato ID Antigo -> ID Novo
 
@@ -162,9 +162,9 @@ Agora você terá acesso a vários novos canais do Discord
 
 - **#devs-chat**
 
-- **#devs-help-me**
+- **#devs-help**
 
-- **#tickets-cleanup**
+- **#ticket-discussion**
 
 - **#ratools**
 

--- a/docs/pt/developer-docs/how-to-become-an-achievement-developer.md
+++ b/docs/pt/developer-docs/how-to-become-an-achievement-developer.md
@@ -13,7 +13,7 @@ Este documento descreve todos os passos que qualquer aspirante a desenvolvedor d
 
 ## Encontrando um Jogo para Trabalhar
 
-Siga as [diretrizes no Código de Conduta dos Desenvolvedores](/guidelines/developers/code-of-conduct#working-on-empty-sets) para encontrar um jogo. Certifique-se de que o jogo esteja em conformidade com as [Regras e Restrições](/developer-docs/jr-dev-rules#rules-and-restrictions) antes de trabalhar nas conquistas. Para reivindicar um jogo, ele deve ter um tópico no fórum. Se ainda não tiver um, você pode pedir a um Revisor de Código para criar um no `#jr-dev-forum` em nosso servidor Discord. Sinta-se à vontade para declarar seus planos de trabalhar no jogo no tópico e postar atualizações conforme prossegue.
+Siga as [diretrizes no Código de Conduta dos Desenvolvedores](/guidelines/developers/code-of-conduct#working-on-empty-sets) para encontrar um jogo. Certifique-se de que o jogo esteja em conformidade com as [Regras e Restrições](/developer-docs/jr-dev-rules#rules-and-restrictions) antes de trabalhar nas conquistas. Para reivindicar um jogo, ele deve ter um tópico no fórum. Se ainda não tiver um, você pode pedir a um Revisor de Código para criar um no `#jr-devs-requests` em nosso servidor Discord. Sinta-se à vontade para declarar seus planos de trabalhar no jogo no tópico e postar atualizações conforme prossegue.
 
 **Dica**: para seu primeiro conjunto de conquistas, é recomendado escolher um jogo que ainda não tenha conquistas **e** não seja muito popular.
 
@@ -89,7 +89,7 @@ Para se familiarizar com essas técnicas, você deve praticar. **Você pode usar
 
 ## Faça seu trabalho ser revisado
 
-Depois de criar algumas conquistas, faça o upload delas para Não oficial e então crie uma postagem em `#jr-dev-forum` em nosso servidor Discord (se você não usa Discord, envie uma mensagem para [RAdmin](http://retroachievements.org/user/RAdmin)) e peça para encontrarem alguém para revisar seu trabalho.
+Depois de criar algumas conquistas, faça o upload delas para Não oficial e então crie uma postagem em `#jr-devs-requests` em nosso servidor Discord (se você não usa Discord, envie uma mensagem para [RAdmin](http://retroachievements.org/user/RAdmin)) e peça para encontrarem alguém para revisar seu trabalho.
 
 **NÃO** peça a outro desenvolvedor para promover suas conquistas para o Core sem uma revisão adequada.
 


### PR DESCRIPTION
I see some discord channel's were renamed and this is a first pass to cleanup some of them.

`jr-dev-forum` -> `jr-devs-requests`
`writing-requests-forum` -> `writing-requests`
`manual-unlock` -> `unlock-requests`
`devs-help-me` -> `devs-help`
`admin-site-cleanup` -> `cleanup-admin`
`tickets-cleanup` -> `ticket-discussion`

also ran `npm run format` for all the other format changes in the PR