### PR TITLE
Update emulator-support-and-issues.md

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -31,6 +31,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
   - Used for Atomiswave and NAOMI 1/2.
 - ✅ Standalone emulator: **[Flycast](https://github.com/flyinghead/flycast/releases)**
   - Used for Atomiswave and NAOMI 1/2.
+  - Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket
 
 ### Arcadia 2001
 
@@ -162,7 +163,6 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 
 - ✅ libretro core: **Gearsystem**
 - ✅ libretro core: **Genesis Plus GX**
-- ✅ libretro core: **PicoDrive**
 - ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
 - ✅ Standalone emulator: **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)**
 
@@ -274,7 +274,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 - ✅ BizHawk core: **PicoDrive**
   - Most recommended.
 - ✅ libretro core: **PicoDrive**
-  - Several games are problematic, use BizHawk if an achievement shows as unsupported.
+  - Several games are problematic, use BizHawk if an achievement shows as unsupported or the game performs poorly.
   - Appears to still have unmapped RAM.
 
 ### Sega CD
@@ -288,6 +288,7 @@ This page focuses on supported emulators. For extensive notes on unsupported emu
 - ✅ libretro core: **Flycast**
   - Disable threaded rendering to properly use save states.
 - ✅ Standalone emulator: **[Flycast](https://github.com/flyinghead/flycast/releases)**
+  - Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket
 
 ### Sega Genesis/Mega Drive
 


### PR DESCRIPTION
-Added some notes about the lack of dev tools for the Flycast standalone and a recommendation to try in the core before opening a ticket  Multiple devs have reported having users open tickets and the issue was resolved by switching to the core.

-Removed Picodrive from Master System.  Game Gear lacks it and is very similar to Master System.  On Master System Picodrive behaves very similarly to SMS Plus GX which is also not supported.

-Added to the several games are problematic part to use Bizhawk if the game performs poorly as well.  With the memory exposure update many of those unsupported games no longer show that, but they perform poorly in the libretro core.