### PR TITLE
Update - remove ambiguous language about PSXReARMed

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -261,8 +261,6 @@ description: Information about unsupported emulators and cores for RetroAchievem
 ## PlayStation
 
 - ❌ libretro core: **PCSX ReARMed**
-  - BIOS are not required for this core and will zero out the Kernel RAM.
-  - Technically supported; not recommended.
 - ❓ BizHawk core: **Octoshock** (Mednafen)
 - ❓ BizHawk core: **Nymashock** (Mednafen)
 - ❓ libretro core: **Rustation**

--- a/docs/pt/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/pt/developer-docs/unsupported-emulators-and-cores.md
@@ -268,8 +268,6 @@ description: Informação sobre emuladores e cores para o RetroAchievements
 ## PlayStation
 
 - ❌ libretro core: **PCSX ReARMed**
-  - BIOS não é necessária para esse core, e irá zerar a RAM do Kernel
-  - Tecnicamente suportado; não recomendado.
 - ❓ BizHawk core: **Octoshock** (Mednafen)
 - ❓ BizHawk core: **Nymashock** (Mednafen)
 - ❓ libretro core: **Rustation**


### PR DESCRIPTION
Removes verbiage that implies PSXReARMed is a supported core.  It is not.