### PR TITLE
Emulator Support and Issues overhaul

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -371,7 +371,7 @@ Limited microphone support.
 ### Sega CD
 
 ::: info
-Appear to still have unmapped RAM.
+These cores appear to still have unmapped RAM.
 :::
 
 | Name                | Type          | Notes |

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -9,7 +9,7 @@ description: Comprehensive guide to hardcore compliance and compatibility for Re
 This page focuses on hardcore-compliant emulators. For detailed compliance requirements, see the [Hardcore Compliance Requirements](/general/hardcore-compliance-requirements) page. For extensive notes on unsupported emulators and cores, check the [unsupported emulators page](/developer-docs/unsupported-emulators-and-cores).
 :::
 
-libretro cores can be played on the following hardcore-compliant frontends. You can find each of them on the [Downloads page](https://retroachievements.org/downloads), listing all cores available for them.:
+libretro cores can be played on the following hardcore-compliant frontends. You can find each of them on the [Downloads page](https://retroachievements.org/downloads), listing all cores available for them:
 
 - [RetroArch](https://www.retroarch.com/index.php?page=platforms) - Supports 45 systems.
 - [RALibRetro](https://retroachievements.org/downloads) - Supports 45 systems.

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -11,10 +11,10 @@ This page focuses on hardcore-compliant emulators. For detailed compliance requi
 
 libretro cores can be played on the following hardcore-compliant frontends. You can find each of them on the [Downloads page](https://retroachievements.org/downloads), listing all cores available for them:
 
-- [RetroArch](https://www.retroarch.com/index.php?page=platforms) - Supports 45 systems.
-- [RALibRetro](https://retroachievements.org/downloads) - Supports 45 systems.
-- [Firelight](https://biscuitcakes.itch.io/firelight) - Supports 10 systems.
-- [Delta (iOS)](https://apps.apple.com/us/app/delta-game-emulator/id1048524688) - Supports 7 systems.
+- [RetroArch](https://www.retroarch.com/index.php?page=platforms) - Supports 40+ systems.
+- [RALibRetro](https://retroachievements.org/downloads) - Supports 40+ systems.
+- [Firelight](https://biscuitcakes.itch.io/firelight) - Supports 10+ systems.
+- [Delta (iOS)](https://apps.apple.com/us/app/delta-game-emulator/id1048524688) - Supports 5+ systems.
 
 BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). More details on BizHawk cores can be found [here](https://tasvideos.org/BizHawk).
 
@@ -174,10 +174,10 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 ### GameCube
 
-| Name                                                                    | Type                | Notes                                                                                                            |
-| :---------------------------------------------------------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------- |
-| **[Dolphin](https://retroachievements.org/download.php#dolphin)**       | Standalone emulator | - Must use version 2407-68 or newer.<br>- Ensure "Enable Dual Core (speedup)" is unchecked as it is unsupported. |
-| **[DolphinUWP](https://github.com/SternXD/dolphin/releases/tag/1.1.9.0) | Standalone emulator |                                                                                                                  |
+| Name                                                                      | Type                | Notes                                                                                                            |
+| :------------------------------------------------------------------------ | :------------------ | :--------------------------------------------------------------------------------------------------------------- |
+| **[Dolphin](https://retroachievements.org/download.php#dolphin)**         | Standalone emulator | - Must use version 2407-68 or newer.<br>- Ensure "Enable Dual Core (speedup)" is unchecked as it is unsupported. |
+| **[DolphinUWP](https://github.com/SternXD/dolphin/releases/tag/1.1.9.0)** | Standalone emulator |                                                                                                                  |
 
 ### Game Gear
 
@@ -253,30 +253,30 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 ### NES/Famicom
 
-| Name                                                 | Type                | Notes                                     |
-| :--------------------------------------------------- | :------------------ | :---------------------------------------- |
-| **FCEUmm**                                           | libretro core       | Most recommended.                         |
-| **Mesen**                                            | libretro core       |                                           |
-| **QuickNES**                                         | libretro core       | Does not emulate the Famicom Disk System. |
-| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                                           |
+| Name                                                           | Type                | Notes                                     |
+| :---------------------------------------------------           | :------------------ | :---------------------------------------- |
+| **FCEUmm**                                                     | libretro core       | Most recommended.                         |
+| **Mesen**                                                      | libretro core       |                                           |
+| **QuickNES**                                                   | libretro core       | Does not emulate the Famicom Disk System. |
+| **[RANes](https://retroachievements.org/downloads)**           | Standalone emulator |                                           |
+| **[NES RA Adapter](https://github.com/odelot/nes-ra-adapter)** | Console adapter     |                   |
 
 ### NES/Famicom Disk System
 
-| Name                                                           | Type                | Notes             |
-| :------------------------------------------------------------- | :------------------ | :---------------- |
-| **FCEUmm**                                                     | libretro core       | Most recommended. |
-| **Mesen**                                                      | libretro core       |                   |
-| **[RANes](https://retroachievements.org/downloads)**           | Standalone emulator |                   |
-| **[NES RA Adapter](https://github.com/odelot/nes-ra-adapter)** | Console adapter     |                   |
+| Name                                                 | Type                | Notes             |
+| :--------------------------------------------------- | :------------------ | :---------------- |
+| **FCEUmm**                                           | libretro core       | Most recommended. |
+| **Mesen**                                            | libretro core       |                   |
+| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                   |
 
 ### Nintendo 64
 
-| Name                                                                            | Type                | Notes                                                                |
-| :------------------------------------------------------------------------------ | :------------------ | :------------------------------------------------------------------- |
-| **Mupen64Plus-Next**                                                            | libretro core       | - Most recommended.<br>- Separated into cores for OpenGL ES 2 and 3. |
-| **ParaLLEl N64**                                                                | libretro core       |                                                                      |
-| **[RAProject64](https://retroachievements.org/downloads)**                      | Standalone emulator |                                                                      |
-| **[Luna Project64](https://github.com/Luna-Project64/Luna-Project64/releases)** | Standalone emulator |                                                                      |
+| Name                                                                              | Type                | Notes                                                                |
+| :-------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------- |
+| **Mupen64Plus-Next**                                                              | libretro core       | - Most recommended.<br>- Separated into cores for OpenGL ES 2 and 3. |
+| **ParaLLEl N64**                                                                  | libretro core       |                                                                      |
+| **[RAProject64](https://retroachievements.org/downloads)**                        | Standalone emulator |                                                                      |
+| **[Luna's Project64](https://github.com/Luna-Project64/Luna-Project64/releases)** | Standalone emulator |                                                                      |
 
 ### Nintendo DS
 

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -118,7 +118,7 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 ### Elektor TV Games Computer
 
 | Name                                                  | Type                | Notes |
-| :---------------------------------------------------- | :------------------ | :---  |
+| :---------------------------------------------------- | :------------------ | :---- |
 | **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
 | **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -9,341 +9,426 @@ description: Comprehensive guide to hardcore compliance and compatibility for Re
 This page focuses on hardcore-compliant emulators. For detailed compliance requirements, see the [Hardcore Compliance Requirements](/general/hardcore-compliance-requirements) page. For extensive notes on unsupported emulators and cores, check the [unsupported emulators page](/developer-docs/unsupported-emulators-and-cores).
 :::
 
+libretro cores can be played on the following hardcore-compliant frontends. You can find each of them on the [Downloads page](https://retroachievements.org/downloads), listing all cores available for them.:
+
+- [RetroArch](https://www.retroarch.com/index.php?page=platforms) - Supports 45 systems.
+- [RALibRetro](https://retroachievements.org/downloads) - Supports 45 systems.
+- [Firelight](https://biscuitcakes.itch.io/firelight) - Supports 10 systems.
+- [Delta (iOS)](https://apps.apple.com/us/app/delta-game-emulator/id1048524688) - Supports 7 systems.
+
+BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). More details on BizHawk cores can be found [here](https://tasvideos.org/BizHawk).
+
+### 32X
+
+| Name          | Type          | Notes                                                                                                                                                     |
+| :------------ | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PicoDrive** | libretro core | - Several games are problematic, use BizHawk if an achievement shows as unsupported or the game performs poorly.<br>- Appears to still have unmapped RAM. |
+| **PicoDrive** | BizHawk core  | Most recommended.                                                                                                                                         |
+
 ### 3DO Interactive Multiplayer
 
-- ✅ libretro core: **Opera**
-  - May have some issues depending on the BIOS.
+| Name      | Type          | Notes                                       |
+| :-------- | :------------ | :------------------------------------------ |
+| **Opera** | libretro core | May have some issues depending on the BIOS. |
 
 ### Amstrad CPC
 
-- ✅ libretro core: **Caprice32**
-  - The core does not currently support writing to disk, which may affect hashing when implemented.
+| Name          | Type          | Notes                                                                                           |
+| :------------ | :------------ | :---------------------------------------------------------------------------------------------- |
+| **Caprice32** | libretro core | The core does not currently support writing to disk, which may affect hashing when implemented. |
 
 ### Apple II
 
-- ✅ Standalone emulator: **[RAppleWin](https://retroachievements.org/download.php#rapplewin)**
+| Name                                                     | Type                 | Notes |
+| :------------------------------------------------------- | :------------------- | :---- |
+| **[RAppleWin](https://retroachievements.org/downloads)** | Standalone emulator  |       |
 
 ### Arcade
 
-- ✅ libretro core: **FinalBurn Neo**
-  - Some boards may not be fully exposed.
-- ✅ libretro core: **Flycast**
-  - Used for Atomiswave and NAOMI 1/2.
-- ✅ Standalone emulator: **[Flycast](https://github.com/flyinghead/flycast/releases)**
-  - Used for Atomiswave and NAOMI 1/2.
-  - Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket
+| Name                                                          | Type                | Notes                                                                                                                                                                                    |
+| :------------------------------------------------------------ | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FinalBurn Neo**                                             | libretro core       | Some boards may not be fully exposed.                                                                                                                                                    |
+| **Flycast**                                                   | libretro core       | Used for Atomiswave and NAOMI 1/2.                                                                                                                                                       |
+| **[Flycast](https://github.com/flyinghead/flycast/releases)** | Standalone emulator | - Used for Atomiswave and NAOMI 1/2.<br>- Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket. |
 
 ### Arcadia 2001
 
-- ✅ Standalone emulator: **[WinArcadia](https://amigan.1emu.net/releases/)**
-- ✅ Standalone emulator: **[DroidArcadia](https://amigan.1emu.net/releases/)**
+| Name                                                  | Type                | Notes |
+| :---------------------------------------------------- | :------------------ | :---- |
+| **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
+| **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 
 ### Arduboy
 
-- ✅ libretro core: **Ardens**
-- ✅ libretro core: **Arduous**
-  - Cannot emulate the Arduboy FX.
+| Name        | Type          | Notes                          |
+| :---------- | :------------ | :----------------------------- |
+| **Ardens**  | libretro core |                                |
+| **Arduous** | libretro core | Cannot emulate the Arduboy FX. |
 
 ### Atari 2600
 
-- ✅ libretro core: **Stella**
-- ✅ BizHawk core: **Atari2600Hawk**
-  - Achievements that require emulator resets do not work. Please open a ticket so the achievement can be fixed.
+| Name              | Type          | Notes                                                                                                        |
+| :---------------- | :------------ | :----------------------------------------------------------------------------------------------------------- |
+| **Stella**        | libretro core |                                                                                                              |
+| **Atari2600Hawk** | BizHawk core  | Achievements that require emulator resets do not work. Please open a ticket so the achievement can be fixed. |
 
 ### Atari 7800
 
-- ✅ libretro core: **ProSystem**
-- ✅ BizHawk core: **A7800Hawk**
+| Name          | Type          | Notes |
+| :------------ | :------------ | :---- |
+| **ProSystem** | libretro core |       |
+| **A7800Hawk** | BizHawk core  |       |
 
 ### Atari Jaguar
 
-- ✅ libretro core: **Virtual Jaguar**
-  - No save state support.
-  - [Many issues with emulation](https://github.com/libretro/virtualjaguar-libretro/issues/38).
-  - Does not emulate the Jaguar CD.
-- ✅ BizHawk core: **Virtual Jaguar**
+| Name               | Type          | Notes                                                                                                                                                          |
+| :----------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Virtual Jaguar** | libretro core | - No save state support.<br>- Does not emulate the Jaguar CD.<br>- [Many issues with emulation](https://github.com/libretro/virtualjaguar-libretro/issues/38). |
+| **Virtual Jaguar** | BizHawk core  |                                                                                                                                                                |
 
 ### Atari Jaguar CD
 
-- ✅ BizHawk core: **Virtual Jaguar**
+| Name               | Type         | Notes |
+| :----------------- | :----------- | :---- |
+| **Virtual Jaguar** | BizHawk core |       |
 
 ### Atari Lynx
 
-- ✅ libretro core: **Handy**
-  - Most recommended.
-- ✅ libretro core: **Beetle Lynx**
-- ✅ BizHawk core: **Handy** (Mednafen's fork)
+| Name            | Type          | Notes                         |
+| :-------------- | :------------ | :---------------------------- |
+| **Handy**       | libretro core | Most recommended.             |
+| **Beetle Lynx** | libretro core |                               |
+| **Handy**       | BizHawk core  | Mednafen's fork specifically. |
 
 ### ColecoVision
 
-- ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
-- ✅ libretro core: **blueMSX**
-- ✅ BizHawk core: **ColecoHawk**
+| Name                                                  | Type                | Notes |
+| :---------------------------------------------------- | :------------------ | :---- |
+| **blueMSX**                                           | libretro core       |       |
+| **ColecoHawk**                                        | BizHawk core        |       |
+| **[RAMeka](https://retroachievements.org/downloads)** | Standalone emulator |       |
+
+### Dreamcast
+
+| Name                                                          | Type                | Notes                                                                                                                                          |
+| :------------------------------------------------------------ | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Flycast**                                                   | libretro core       | Disable threaded rendering to properly use save states.                                                                                        |
+| **[Flycast](https://github.com/flyinghead/flycast/releases)** | Standalone emulator | Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket. |
 
 ### Elektor TV Games Computer
 
-- ✅ Standalone emulator: **[WinArcadia](https://amigan.1emu.net/releases/)**
-- ✅ Standalone emulator: **[DroidArcadia](https://amigan.1emu.net/releases/)**
+| Name                                                  | Type                | Notes |
+| :---------------------------------------------------- | :------------------ | :---  |
+| **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
+| **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 
 ### Fairchild Channel F
 
-- ✅ libretro core: **FreeChaF**
-
-### Famicom Disk System
-
-- ✅ libretro core: **FCEUmm**
-- ✅ libretro core: **Mesen**
-- ✅ Standalone emulator: **[RANes](https://retroachievements.org/download.php#ranes)**
+| Name         | Type          | Notes |
+| :----------- | :------------ | :---- |
+| **FreeChaF** | libretro core |       |
 
 ### Game Boy
 
-- ✅ libretro core: **Gambatte**
-  - Most recommended.
-- ✅ libretro core: **Gearboy**
-- ✅ libretro core: **mGBA**
-- ✅ libretro core: **VBA-M**
-- ✅ BizHawk core: **Gambatte** (Pokémon speedrunning fork)
-- ✅ BizHawk core: **GBHawk**
-- ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
-- ✅ Standalone emulator: **[Pizza Boy C Basic & Pro](https://pizzaemulators.com/)**
+| Name                                                         | Type                | Notes |
+| :----------------------------------------------------------- | :------------------ | :-------------------------------------- |
+| **Gambatte**                                                 | libretro core       | Most recommended.                       |
+| **Gearboy**                                                  | libretro core       |                                         |
+| **mGBA**                                                     | libretro core       |                                         |
+| **VBA-M**                                                    | libretro core       |                                         |
+| **Gambatte**                                                 | BizHawk core        | Pokémon speedrunning fork specifically. |
+| **GBHawk**                                                   | BizHawk core        |                                         |
+| **[RAVBA](https://retroachievements.org/downloads)**         | Standalone emulator |                                         |
+| **[Pizza Boy C Basic & Pro](https://pizzaemulators.com/)**   | Standalone emulator |                                         |
+| **[SkyEmu](https://github.com/skylersaleh/SkyEmu/pull/321)** | Standalone emulator |                                         |
+| **[Playback](https://www.epilogue.co/)**                     | Standalone emulator | GB Operator device required.            |
 
 ### Game Boy Color
 
-- ✅ libretro core: **Gambatte**
-  - Most recommended.
-- ✅ libretro core: **Gearboy**
-- ✅ libretro core: **mGBA**
-- ✅ libretro core: **VBA-M**
-- ✅ BizHawk core: **Gambatte** (Pokémon speedrunning fork)
-- ✅ BizHawk core: **GBHawk**
-- ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
-- ✅ Standalone emulator: **[Pizza Boy C Basic & Pro](https://pizzaemulators.com/)**
+| Name                                                         | Type                | Notes |
+| :----------------------------------------------------------- | :------------------ | :-------------------------------------- |
+| **Gambatte**                                                 | libretro core       | Most recommended.                       |
+| **Gearboy**                                                  | libretro core       |                                         |
+| **mGBA**                                                     | libretro core       |                                         |
+| **VBA-M**                                                    | libretro core       |                                         |
+| **Gambatte**                                                 | BizHawk core        | Pokémon speedrunning fork specifically. |
+| **GBHawk**                                                   | BizHawk core        |                                         |
+| **[RAVBA](https://retroachievements.org/downloads)**         | Standalone emulator |                                         |
+| **[Pizza Boy C Basic & Pro](https://pizzaemulators.com/)**   | Standalone emulator |                                         |
+| **[SkyEmu](https://github.com/skylersaleh/SkyEmu/pull/321)** | Standalone emulator |                                         |
+| **[Playback](https://www.epilogue.co/)**                     | Standalone emulator | GB Operator device required.            |
 
 ### Game Boy Advance
 
-- ✅ libretro core: **mGBA**
-  - Most recommended.
-- ✅ libretro core: **VBA-M**
-- ✅ libretro core: **Beetle GBA**
-- ✅ libretro core: **VBA Next**
-- ✅ BizHawk core: **mGBA**
-- ✅ Standalone emulator: **[RAVBA](https://retroachievements.org/download.php#ravba)**
-- ✅ Standalone emulator: **[Pizza Boy A Basic & Pro](https://pizzaemulators.com/)**
+| Name                                                         | Type                | Notes|
+| :----------------------------------------------------------- | :------------------ | :--------------------------- |
+| **mGBA**                                                     | libretro core       | Most recommended.            |
+| **VBA-M**                                                    | libretro core       |                              |
+| **Beetle GBA**                                               | libretro core       |                              |
+| **VBA Next**                                                 | libretro core       |                              |
+| **mGBA**                                                     | BizHawk core        |                              |
+| **[RAVBA](https://retroachievements.org/downloads)**         | Standalone emulator |                              |
+| **[Pizza Boy C Basic & Pro](https://pizzaemulators.com/)**   | Standalone emulator |                              |
+| **[SkyEmu](https://github.com/skylersaleh/SkyEmu/pull/321)** | Standalone emulator |                              |
+| **[Playback](https://www.epilogue.co/)**                     | Standalone emulator | GB Operator device required. |
 
 ### GameCube
 
-- ✅ Standalone emulator: **[Dolphin](https://retroachievements.org/download.php#dolphin)**
-  - Must use version 2407-68 or newer.
-  - Ensure "Enable Dual Core (speedup)" is unchecked as it is unsupported.
+| Name                                                                    | Type                | Notes                                                                                                            |
+| :---------------------------------------------------------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------- |
+| **[Dolphin](https://retroachievements.org/download.php#dolphin)**       | Standalone emulator | - Must use version 2407-68 or newer.<br>- Ensure "Enable Dual Core (speedup)" is unchecked as it is unsupported. |
+| **[DolphinUWP](https://github.com/SternXD/dolphin/releases/tag/1.1.9.0) | Standalone emulator |                                                                                                                  |
 
 ### Game Gear
 
-- ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
-- ✅ libretro core: **Genesis Plus GX**
-- ✅ libretro core: **Gearsystem**
-- ✅ Standalone emulator: **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)**
+| Name                                                        | Type                | Notes |
+| :---------------------------------------------------------- | :------------------ | :---- |
+| **Genesis Plus GX**                                         | libretro core       |       |
+| **Gearsystem**                                              | libretro core       |       |
+| **[RAMeka](https://retroachievements.org/downloads)**       | Standalone emulator |       |
+| **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)** | Standalone emulator |       |
+
+### Genesis/Mega Drive
+
+| Name                                                        | Type                | Notes                          |
+| :---------------------------------------------------------- | :------------------ | :----------------------------- |
+| **Genesis Plus GX**                                         | libretro core       | Most recommended.              |
+| **PicoDrive**                                               | libretro core       |                                |
+| **Genplus-gx**                                              | BizHawk core        | Also known as Genesis Plus GX. |
+| **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)** | Standalone Emulator |                                |
 
 ### Intellivision
 
-- ✅ libretro core: **FreeIntv**
-  - Crashes when the game is reset.
-  - Some crashes might be related to the Intellivoice not being emulated.
-- ✅ BizHawk core: **IntelliHawk**
+| Name            | Type          | Notes                                                                                                        |
+| :-------------- | :------------ | :----------------------------------------------------------------------------------------------------------- |
+| **FreeIntv**    | libretro core | - Crashes when the game is reset.<br>- Some crashes might be related to the Intellivoice not being emulated. |
+| **IntelliHawk** | BizHawk core  |                                                                                                              |
 
 ### Interton VC 4000
 
-- ✅ Standalone emulator: **[WinArcadia](https://amigan.1emu.net/releases/)**
-- ✅ Standalone emulator: **[DroidArcadia](https://amigan.1emu.net/releases/)**
+| Name                                                  | Type                | Notes |
+| :---------------------------------------------------- | :------------------ | :---  |
+| **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
+| **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 
 ### Magnavox Odyssey 2
 
-- ✅ libretro core: **O2EM**
+| Name     | Type          | Notes |
+| :------- | :------------ | :---- |
+| **O2EM** | libretro core |       |
 
 ### Master System/Mark III
 
-- ✅ libretro core: **Gearsystem**
-- ✅ libretro core: **Genesis Plus GX**
-- ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
-- ✅ Standalone emulator: **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)**
+| Name                                                        | Type                | Notes |
+| :---------------------------------------------------------- | :------------------ | :---- |
+| **Genesis Plus GX**                                         | libretro core       |       |
+| **Gearsystem**                                              | libretro core       |       |
+| **[RAMeka](https://retroachievements.org/downloads)**       | Standalone emulator |       |
+| **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)** | Standalone emulator |       |
 
 ### Mega Duck
 
-- ✅ libretro core: **SameDuck**
+| Name         | Type          | Notes |
+| :----------- | :------------ | :---- |
+| **SameDuck** | libretro core |       |
 
 ### MSX
 
-- ✅ libretro core: **blueMSX**
+| Name        | Type          | Notes |
+| :---------- | :------------ | :---- |
+| **blueMSX** | libretro core |       |
 
 ### Neo Geo CD
 
-- ✅ libretro core: **NeoCD**
+| Name      | Type          | Notes |
+| :-------- | :------------ | :---- |
+| **NeoCD** | libretro core |       |
 
 ### Neo Geo Pocket (Color)
 
-- ✅ libretro core: **Beetle NeoPop**
-- ✅ BizHawk core: **NeoPop** (Mednafen)
+| Name              | Type          | Notes                       |
+| :---------------- | :------------ | :-------------------------- |
+| **Beetle NeoPop** | libretro core |                             |
+| **NeoPop**        | BizHawk core  | Mednafen fork specifically. |
 
 ### NES/Famicom
 
-- ✅ libretro core: **FCEUmm**
-  - Most recommended.
-- ✅ libretro core: **Mesen**
-- ✅ libretro core: **QuickNES**
-  - Does not emulate the Famicom Disk System.
-- ✅ Standalone emulator: **[RANes](https://retroachievements.org/download.php#ranes)**
-- ✅ Standalone emulator: **[Delta](https://faq.deltaemulator.com/)**
+| Name                                                 | Type                | Notes                                     |
+| :--------------------------------------------------- | :------------------ | :---------------------------------------- |
+| **FCEUmm**                                           | libretro core       | Most recommended.                         |
+| **Mesen**                                            | libretro core       |                                           |
+| **QuickNES**                                         | libretro core       | Does not emulate the Famicom Disk System. |
+| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                                           |
+
+### NES/Famicom Disk System
+
+| Name                                                 | Type                | Notes             |
+| :--------------------------------------------------- | :------------------ | :---------------- |
+| **FCEUmm**                                           | libretro core       | Most recommended. |
+| **Mesen**                                            | libretro core       |                   |
+| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                   |
 
 ### Nintendo 64
 
-- ✅ libretro core: **Mupen64Plus-Next**
-  - Most recommended.
-  - Separated into cores for OpenGL ES 2 and 3.
-- ✅ libretro core: **ParaLLEl N64**
-- ✅ Standalone emulator: **[RAProject64](https://retroachievements.org/download.php#rap64)**
-- ✅ Standalone emulator: **[Luna Project64](https://github.com/Luna-Project64/Luna-Project64/releases)**
-- ✅ Standalone emulator: **[Delta](https://faq.deltaemulator.com/)**
+| Name                                                                            | Type                | Notes                                                                |
+| :------------------------------------------------------------------------------ | :------------------ | :------------------------------------------------------------------- |
+| **Mupen64Plus-Next**                                                            | libretro core       | - Most recommended.<br>- Separated into cores for OpenGL ES 2 and 3. |
+| **ParaLLEl N64**                                                                | libretro core       |                                                                      |
+| **[RAProject64](https://retroachievements.org/downloads)**                      | Standalone emulator |                                                                      |
+| **[Luna Project64](https://github.com/Luna-Project64/Luna-Project64/releases)** | Standalone emulator |                                                                      |
 
 ### Nintendo DS
 
-- Limited microphone support.
-- ✅ libretro core: **DeSmuME**
-  - Does not emulate the DSi.
-- ✅ libretro core: **melonDS**
-- ✅ libretro core: **melonDS DS**
-- ✅ BizHawk core: **melonDS**
-- ✅ Standalone emulator: **[melonDS Android](https://github.com/rafaelvcaetano/melonDS-android/releases)**
+::: info
+Limited microphone support.
+:::
+
+| Name                                                                              | Type                | Notes                     |
+| :-------------------------------------------------------------------------------- | :------------------ | :------------------------ |
+| **DeSmuME**                                                                       | libretro core       | Does not emulate the DSi. |
+| **melonDS**                                                                       | libretro core       |                           |
+| **melonDS DS**                                                                    | libretro core       |                           |
+| **melonDS**                                                                       | BizHawk core        |                           |
+| **[melonDS Android](https://github.com/rafaelvcaetano/melonDS-android/releases)** | Standalone emulator |                           |
 
 ### Nintendo DSi
 
-- ✅ libretro core: **melonDS DS**
-  - Does not support save states at this time.
-- ✅ BizHawk core: **melonDS**
-- ✅ Standalone emulator: **[melonDS Android](https://github.com/rafaelvcaetano/melonDS-android/releases)**
+| Name                                                                              | Type                | Notes                                      |
+| :-------------------------------------------------------------------------------- | :------------------ | :----------------------------------------- |
+| **melonDS DS**                                                                    | libretro core       | Does not support save states at this time. |
+| **melonDS**                                                                       | BizHawk core        |                                            |
+| **[melonDS Android](https://github.com/rafaelvcaetano/melonDS-android/releases)** | Standalone emulator |                                            |
 
 ### PC Engine/TurboGrafx-16/SuperGrafx
 
-- ✅ libretro core: **Beetle SuperGrafx**
-  - Most recommended.
-- ✅ libretro core: **Beetle PCE Fast**
-  - SuperGrafx games do not work on the Beetle PCE Fast core.
-- ✅ BizHawk core: **PCEHawk**
+| Name                  | Type          | Notes                                                     |
+| :-------------------- | :------------ | :-------------------------------------------------------- |
+| **Beetle SuperGrafx** | libretro core | Most recommended.                                         |
+| **Beetle PCE Fast**   | libretro core | SuperGrafx games do not work on the Beetle PCE Fast core. |
+| **PCEHawk**           | BizHawk core  |                                                           |
 
 ### PC Engine CD/TurboGrafx-CD
 
-- ✅ libretro core: **Beetle SuperGrafx**
-  - Most recommended.
-- ✅ libretro core: **Beetle PCE Fast**
-- ✅ BizHawk core: **PCEHawk**
+| Name                  | Type          | Notes             |
+| :-------------------- | :------------ | :---------------- |
+| **Beetle SuperGrafx** | libretro core | Most recommended. |
+| **Beetle PCE Fast**   | libretro core |                   |
+| **PCEHawk**           | BizHawk core  |                   |
 
 ### PC-8000/8800
 
-- ✅ libretro core: **QUASI88**
-- ✅ Standalone emulator: **[RAQUASI88](https://retroachievements.org/download.php#raquasi88)**
+| Name                                                                  | Type                | Notes |
+| :-------------------------------------------------------------------- | :------------------ | :---- |
+| **QUASI88**                                                           | libretro core       |       |
+| **[RAQUASI88](https://retroachievements.org/downloads)** | Standalone emulator |       |
 
 ### PC-FX
 
-- ✅ libretro core: **Beetle PC-FX**
-- ✅ BizHawk core: **T.S.T.** (Mednafen)
+| Name                  | Type          | Notes                       |
+| :-------------------- | :------------ | :-------------------------- |
+| **Beetle PC-FX**      | libretro core |                             |
+| **T.S.T.**            | BizHawk core  | Mednafen fork specifically. |
 
 ### PlayStation
 
-- ✅ libretro core: **Beetle PSX HW**
-  - Most recommended.
-- ✅ libretro core: **Beetle PSX**
-- ✅ libretro core: **SwanStation**
-- ✅ Standalone emulator: **[DuckStation](https://www.duckstation.org/)**
-  - There may be memory leaks and/or burn-in when using save states. This can be disruptive to softcore mode.
+| Name                                            | Type                | Notes                                                                                                     |
+| :---------------------------------------------- | :------------------ | :-------------------------------------------------------------------------------------------------------- |
+| **Beetle PSX HW**                               | libretro core       | Most recommended.                                                                                         |
+| **Beetle PSX**                                  | libretro core       |                                                                                                           |
+| **SwanStation**                                 | libretro core       |                                                                                                           |
+| **[DuckStation](https://www.duckstation.org/)** | Standalone emulator | There may be memory leaks and/or burn-in when using save states. This can be disruptive to softcore mode. |
 
 ### PlayStation 2
 
-- ✅ Standalone emulator: **[PCSX2](https://pcsx2.net/)**
-- ✅ Standalone emulator: **[NetherSX2](https://github.com/Trixarian/NetherSX2-classic/releases)**
-- ✅ Standalone emulator: **[XBSX2](https://github.com/XboxEmulationHub/XBSX2/releases)**
+| Name                                                                     | Type                | Notes |
+| :----------------------------------------------------------------------- | :------------------ | :---- |
+| **[PCSX2](https://pcsx2.net/)**                                          | Standalone emulator |       |
+| **[NetherSX2](https://github.com/Trixarian/NetherSX2-classic/releases)** | Standalone emulator |       |
+| **[XBSX2](https://github.com/XboxEmulationHub/XBSX2/releases)**          | Standalone emulator |       |
 
 ### PlayStation Portable
 
-- ✅ Standalone emulator: **[PPSSPP](https://www.ppsspp.org/download/)**
-- ✅ libretro core: **PPSSPP**
+| Name                                       | Type                | Notes |
+| :----------------------------------------- | :------------------ | :---- |
+| **PPSSPP**                                 | libretro core       |       |
+| **[PPSSPP](https://ppsspp.org/download/)** | Standalone emulator |       |
 
 ### Pokémon Mini
 
-- ✅ libretro core: **PokeMini**
+| Name         | Type          | Notes |
+| :----------- | :------------ | :---- |
+| **PokeMini** | libretro core |       |
 
-### Sega 32X
+### Saturn
 
-- ✅ BizHawk core: **PicoDrive**
-  - Most recommended.
-- ✅ libretro core: **PicoDrive**
-  - Several games are problematic, use BizHawk if an achievement shows as unsupported or the game performs poorly.
-  - Appears to still have unmapped RAM.
+| Name                                          | Type                | Notes                                              |
+| :-------------------------------------------- | :------------------ | :------------------------------------------------- |
+| **Beetle Saturn**                             | libretro core       |                                                    |
+| **Saturnus**                                  | BizHawk core        | Good choice for users who can't run Beetle Saturn. |
+| **[Yaba Sanshiro](https://yabasanshiro.com)** | Standalone emulator | Currently only on Android.                         |
 
 ### Sega CD
 
-- Appears to still have unmapped RAM.
-- ✅ libretro core: **Genesis Plus GX**
-- ✅ libretro core: **PicoDrive**
+::: info
+Appear to still have unmapped RAM.
+:::
 
-### Sega Dreamcast
-
-- ✅ libretro core: **Flycast**
-  - Disable threaded rendering to properly use save states.
-- ✅ Standalone emulator: **[Flycast](https://github.com/flyinghead/flycast/releases)**
-  - Achievement developers have no way to troubleshoot issues directly, if an achievement doesn't work try using the core before opening a ticket
-
-### Sega Genesis/Mega Drive
-
-- ✅ libretro core: **Genesis Plus GX**
-  - Most recommended.
-- ✅ libretro core: **PicoDrive**
-- ✅ BizHawk core: **Genplus-gx** (Genesis Plus GX)
-- ✅ Standalone emulator: **[Pizza Boy SC Basic & Pro](https://pizzaemulators.com/)**
-
-### Sega Saturn
-
-- ✅ libretro core: **Beetle Saturn**
-- ✅ BizHawk core: **Saturnus** (Mednafen)
-  - Good choice for users who can't run Beetle Saturn
+| Name                | Type          | Notes |
+| :------------------ | :------------ | :---- |
+| **Genesis Plus GX** | libretro core |       |
+| **PicoDrive**       | libretro core |       |
 
 ### SG-1000
 
-- ✅ libretro core: **Genesis Plus GX**
-  - Most recommended.
-- ✅ libretro core: **blueMSX**
-- ✅ Standalone emulator: **[RAMeka](https://retroachievements.org/download.php#rameka)**
+| Name                                                  | Type                | Notes             |
+| :---------------------------------------------------- | :------------------ | :---------------- |
+| **Genesis Plux GX**                                   | libretro core       | Most recommended. |
+| **blueMSX**                                           | libretro core       |                   |
+| **[RAMeka](https://retroachievements.org/downloads)** | Standalone emulator |                   |
 
 ### SNES/Super Famicom/Satellaview/Sufami Turbo
 
-- ✅ libretro core: **Snes9x**
-  - Most recommended.
-- ✅ libretro core: **Mesen-S**
-- ✅ Standalone emulator: **[RASnes9x](https://retroachievements.org/download.php#rasnes9x)**
-- ✅ Standalone emulator: **[Delta](https://faq.deltaemulator.com/)**
+| Name                                                                | Type                | Notes             |
+| :------------------------------------------------------------------ | :------------------ | :---------------- |
+| **Snes9X**                                                          | libretro core       | Most recommended. |
+| **Mesen-S**                                                         | libretro core       |                   |
+| **[RASnes9x](https://retroachievements.org/download.php#rasnes9x)** | Standalone emulator |                   |
 
 ### Uzebox
 
-- ✅ BizHawk core: **Uzem**
-- ✅ libretro core: **Uzebox**
+| Name       | Type          | Notes |
+| :--------- | :------------ | :---- |
+| **Uzebox** | libretro core |       |
+| **Uzem**   | BizHawk core  |       |
 
 ### Vectrex
 
-- ✅ libretro core: **vecx**
+| Name     | Type          | Notes |
+| :------- | :------------ | :---- |
+| **vecx** | libretro core |       |
 
 ### Virtual Boy
 
-- ✅ libretro core: **Beetle VB**
-- ✅ BizHawk core: **Virtual Boyee** (Mednafen)
+| Name              | Type          | Notes                       |
+| :---------------- | :------------ | :-------------------------- |
+| **Beetle VB**     | libretro core |                             |
+| **Virtual Boyee** | BizHawk core  | Mednafen fork specifically. |
 
 ### WASM-4
 
-- ✅ libretro core: **WASM-4**
+| Name       | Type          | Notes |
+| :--------- | :------------ | :---- |
+| **WASM-4** | libretro core |       |
 
 ### Watara Supervision
 
-- ✅ libretro core: **Potator**
+| Name        | Type          | Notes |
+| :-------    | :------------ | :---- |
+| **Potator** | libretro core |       |
 
 ### WonderSwan (Color)
 
-- ✅ libretro core: **Beetle Cygne**
-- ✅ BizHawk core: **Cygne** (Mednafen)
-
-More details on BizHawk cores can be found [here](https://tasvideos.org/BizHawk).
+| Name             | Type          | Notes                       |
+| :--------------- | :------------ | :-------------------------- |
+| **Beetle Cygne** | libretro core |                             |
+| **Cygne**        | BizHawk core  | Mednafen fork specifically. |

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -262,11 +262,12 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 ### NES/Famicom Disk System
 
-| Name                                                 | Type                | Notes             |
-| :--------------------------------------------------- | :------------------ | :---------------- |
-| **FCEUmm**                                           | libretro core       | Most recommended. |
-| **Mesen**                                            | libretro core       |                   |
-| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                   |
+| Name                                                           | Type                | Notes             |
+| :------------------------------------------------------------- | :------------------ | :---------------- |
+| **FCEUmm**                                                     | libretro core       | Most recommended. |
+| **Mesen**                                                      | libretro core       |                   |
+| **[RANes](https://retroachievements.org/downloads)**           | Standalone emulator |                   |
+| **[NES RA Adapter](https://github.com/odelot/nes-ra-adapter)** | Console adapter     |                   |
 
 ### Nintendo 64
 
@@ -393,6 +394,7 @@ Appear to still have unmapped RAM.
 | **Snes9X**                                                          | libretro core       | Most recommended. |
 | **Mesen-S**                                                         | libretro core       |                   |
 | **[RASnes9x](https://retroachievements.org/download.php#rasnes9x)** | Standalone emulator |                   |
+| **[RA2Snes](https://github.com/Factor-64/RA2Snes/releases)**        | Console adapter     |                   |
 
 ### Uzebox
 


### PR DESCRIPTION
Big overhaul of the Emulator Support and Issues docs, which includes:

- Converting all lists to tables.
- Adding previously-missed hardcore-compliant emulators (DolphinUWP, SkyEmu, Yaba Sanshiro).
- Remove Delta from each system.
- Add intro with hardcore-compliant frontends (including Delta).
- Re-arrange Sega systems to follow on-site naming.