### PR TITLE
DevQuest miscellaneous updates

### DIFF
--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -2,26 +2,33 @@
 
 ## What are DevQuests?
 
-DevQuests are achievement development-related quests that Developers can take part in at any time. Each one has a specific goal and upon reaching that goal, the achievement developer will earn the badge. DevQuests are not available for Junior Developers.
+DevQuests are achievement development-related quests that developers can take part in at any time. Each one has a specific goal and upon reaching that goal, the achievement developer will earn a badge. 
 
 ## General Rules
+Outside exceptions explicitely written in the individual quest rules, quests of each type follow the general rules below:
+- DevQuests are not available for Junior Developers.
+- To be awarded credit towards a quest, ping the team via a Discord ping in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002) or via [site message](https://retroachievements.org/messages/create?to=DevQuest) within one week of completion, with a link to the appropriate achievement page.
+- Collaborations and subsets are not allowed by default.
 
-1. **Set-Creation Credit**: To be awarded credit for Set-Creation quests, contact the DevQuest Team via Discord ping in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002) or via [site message](https://retroachievements.org/messages/create?to=DevQuest) within 1 week after publishing the set. Include a link to the game and which DevQuest it is being used for. (No need to do this for DevQuest 015 or 020 -- We handle those in sweeps separately). Note: Sets may still be disqualified for quality or rules reasons at this point. Contact us prior to release if you wish to confirm eligibility.
-2. **Maintenance Quest Credit**: For maintenance achievements (i.e. DevQuest 001, DevQuest 005, DevQuest 014, etc.), just create a column in the DevQuest Remastered sheet to the left of completed entries and fill it in as you work. Contact the DevQuest team when you are complete with all entries for review. For Maintenance Quests that can be repeated, one row of the column will be for which badge number you are working towards.
-3. **Revision Quest Credit**: For Revision achievements (i.e. DevQuest 002 and DevQuest 013), make sure your choice is already on the corresponding approved list. You will need to satisfy the repair plan. These quests should be more than simple one-achievement revisions. If a repair plan seems to be overly simple, contact us first to ensure it will qualify. **When you start working on a revision quest, contact the DevQuest team** so the sheet can be updated; this lets other users know it is being worked on.
-4. Unless otherwise stated in a DevQuest's description, collaborations are not allowed.
-5. Standard set quality or better is expected for DevQuest sets. If a set appears to be of insufficient effort or a copy/paste set, it may be rejected at the DevQuest team's discretion. Rich Presence is required for DevQuest sets. The DevQuest team is happy to suggest improvements for qualification.
-6. New sets may only be applied towards one Set Creation DevQuest. No double-dipping.
-7. Always contact the active authors on sets whose content you will update or add to.
+Quest type specific rules:
 
-## Reporting
+**Set-Creation**
+- Making a set can only contribute to a single quest. For example, if you make a set for a Japan-exclusive game with a female protagonist that was featured on Wish This Set, you have to choose between [DQ8](#_008-world-traveler), [DQ16](#_016-wish-this-set) and [DQ24](#_024-she-s-got-this), you don't get all three.
+- Standard set quality or better is expected for DevQuest sets. If a set appears to be of insufficient effort, it may be rejected at the DevQuest team's discretion. Rich Presence is required for DevQuest sets. The DevQuest team is happy to suggest improvements for qualification.
 
-- Contact the team using the DevQuest team via [site message](https://retroachievements.org/messages/create?to=DevQuest) or on in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002) on Discord.
+**Maintenance**
+- You cannot be an original author on the set being maintained.
+- General revision rules apply: contact the active authors on sets whose content you will update or add to. Moreover, discussions, dev votes and revision claims are required when adding new achievements to a set.
+- Every action can only contribute to a single quest. For example, if you repair a set for [DQ2](#_002-retro-renovator), resolving tickets is part of that task, so these tickets cannot be tallied up towards [DQ1](#_001-ticket-massacre).  However, some sets can benefit from different independant actions in a way that yields credits towards multiple DevQuests. If you add a rich presence, leaderboards and revise a set to cover content that was missing before, you could get credit for DQ13, DQ14 and DQ22.
+- For revision quests ([DQ2](#_002-retro-renovator), [DQ13](#_013-complete-me) and [DQ22](#_022-this-belonged-in-a-museum) Dust-offs), the game needs to be in the approved list. You may propose games you feel should qualify prior to working on them and the team will determine if it fits the quest. While [DQ13](#_013-complete-me) credit can sometimes be granted along [DQ2](#_002-retro-renovator) or [DQ22](#_022-this-belonged-in-a-museum), this is up to a team vote and should only be allowed when both the current content and missing content require significant work.
+- When you update the logic of any asset, keep a backup of the old logic posted in the game's official forum for reference.
+- For miscellaneous maintenance quests ([DQ1](#_001-ticket-massacre), [DQ3](#_003-singles-in-your-area), [DQ5](#_005-trigger-happy) and [DQ14](#_014-laudable-leaderboards)), create a column in the DevQuest Remastered sheet to the left of completed entries and fill it in as you work. Contact the DevQuest team for review only after you have completed the quest. For quests that can be repeated, one row of the column will be for which badge number you are working towards.
 
-## Schedule and Announcements
+**Legacy**
 
-- DevQuests do not have a specific release schedule. Typically, they are announced shortly after their badge has been completed.
-- New DevQuests and any updates to existing DevQuests will be announced in [`#developer-news`](https://discord.com/channels/310192285306454017/386068797921951755) on the RetroAchievements Discord and site news
+Legacy quests ([DQ4](#_004-veteran-developer), [DQ15](#_015-console-conqueror) and [DQ20](#_020-genre-conqueror)) are fully retroactive and are awarded for having an extensive and wide portfolio as a developer.
+- You may request to be tracked for these after reaching some minimum treshold as determined in the rules of each individual quests.
+- Following that first tracking request, updates are made in sweeps periodically; this means you don't have to (and shouldn't) ping the team every time you complete a new set that adds to your portfolio. Every couple months, the dev responsible for the sweeps for that particular quest will update the status of everyone being tracked and announce the progress in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002).
 
 ## The Quests
 
@@ -68,7 +75,6 @@ DevQuests are achievement development-related quests that Developers can take pa
 2. You do not need a revision vote to tighten up this kind of logic.
 3. Achievements cannot be your own, you should just fix these anyway!
 4. You must comment on each achievement or in the forum on what you changed for log purposes.
-5. May not overlap with the required repair plan for DevQuest 002 or with any completion requirements for DevQuest 013.
 
 ### 004 [Veteran Developer](https://retroachievements.org/game/15947)
 
@@ -104,9 +110,8 @@ A constantly evolving toolkit means that these requirements are subject to chang
 1. Must **put measured and/or triggered where it makes sense**. Do so on all appropriate achievements in the set. Achievements with unnecessary use will not be counted. If you hit 50 and there is more in a set to update, you must update the rest of the set.
 2. You can do achievements in your **own sets** at half credit. Put both achievements on the same line, with a / between them. **Link** each achievement ID to the achievement's page.
 3. You **must** _leave comments_ on set page for what you changed for log purposes
-4. May not overlap with the required repair plan for DevQuest 2 or with any completion requirements for DQ13.
-5. **TEST all changes**. Ensure triggers appear when they should, and do not appear when they should not. Ensure the achievement can still trigger when expected.
-6. **Subscribe to tickets** on the updated sets so you can catch any `Trigger` or `Measured` related tickets.
+4. **TEST all changes**. Ensure triggers appear when they should, and do not appear when they should not. Ensure the achievement can still trigger when expected.
+5. **Subscribe to tickets** on the updated sets so you can catch any `Trigger` or `Measured` related tickets.
 
 ### 006 [The Unwanted](https://retroachievements.org/game/15907)
 
@@ -159,7 +164,7 @@ No hacks or homebrew unless those are the only types of games left without sets.
 At the time you claim the set, it must be in Most Wanted section of the latest issue of RANews.
 :::
 
-1. If you already have one claimed when the game becomes eligible, you must be under 50% progress for it to count.
+1. If you already have one claimed when the game becomes eligible, you must be under 50% progress for it to count. Please reach out to the team to confirm eligibility when that happens.
 2. Any games listed in the console-specific bonus section in RANews will only be eligible to be claimed in the month it was featured in, but the set doesn't need to be released in the same month.
 
 ### 008 [World Traveler](https://retroachievements.org/game/15918)
@@ -305,7 +310,7 @@ You must have developed sets for 10 or more supported systems before opt-in. Opt
 **Goal**: Publish a set for a game that has been featured in RANews' Wish This Set feature at any point in time and does not currently have a set in core  
 **Repeatable**: Yes (Up to 2 times)
 
-1. Collaborations are Acceptable as long as both contribute equally to the set with a minimum of 20 achievements each.
+1. Collaborations are acceptable as long as both contribute equally to the set with a minimum of 20 achievements each.
 2. Must be full sets containing all content and challenges appropriate to the game.
 3. The person that wrote the Wish This Set may not be one of the developers making the set.
 4. Quest is available year round, and gets new games eligible every release of RANews.
@@ -434,11 +439,10 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
    - [Outdated Version](https://retroachievements.org/hub/29482)
       - If you identify a set you believe should qualify for a task like this, simply request approval from the team. Providing support to an updated version of a hack, homebrew or language patch will yield 1 point regardless of if it was tagged as outdated, provided the update required actual logic updates and/or adding achievements to cover added content.
 4. No collaboration allowed.
-5. This quest does not stack with other revision DevQuests. If a set would also be eligible to DQ2 or DQ13 those quests will take priority.
-6. Sets are subject to DevQuest team approval, along with a small plan on what the dust-off will be about. Sets already in the approved DQ22 list do not require approval, only notification.
-7. Badge updates must go through the Icon-Gauntlet revision process.
-8. Revision rules apply as usual, meaning if you only clean-up the logic and don't change the achievements scope you don't need one.
-9. Devs' own sets made prior to 2024 are eligible for half the points on a Full Dust-Off. As with sets that are not pre-approved, they will need to be sent to the DevQuest team for approval.
+5. Sets are subject to DevQuest team approval, along with a small plan on what the dust-off will be about. Sets already in the approved DQ22 list do not require approval, only notification.
+6. Badge updates must go through the Icon-Gauntlet revision process.
+7. Revision rules apply as usual, meaning if you only clean-up the logic and don't change the achievements scope you don't need one.
+8. Devs' own sets made prior to 2024 are eligible for half the points on a Full Dust-Off. As with sets that are not pre-approved, they will need to be sent to the DevQuest team for approval.
 
 ### 023 [Well of Wishes](https://retroachievements.org/event/170-devquest-023-well-of-wishes)
 
@@ -479,28 +483,14 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
 6. Each point of credit (equivalent to one set) must have a different female character as the protagonist (or different ensemble of female characters)
 
 ## Wheel Spin DevQuest Rules
-
-1. You may respin 3 months after you spin. This requires and consumes your respin token for that quest
-2. You start with one respin token (per applicable DevQuest)
-3. Each wheel spin quest has its own kind of respin token (can't save your DevQuest 006 token for use in DevQuest 019)
-4. You may not bank extra respin tokens
-5. Once you have used your respin token, you may restore it by fulfilling one of the Respin Tasks, listed below
-
-### Devquests With Wheel Spins
-
-- DevQuest 006: The Unwanted
-- DevQuest 019: Wheel of Genres
-- DevQuest 023: Well of Wishes
-
-### Respin Tasks
-
-Do any of these tasks to earn a new respin token:
-
-- Resolve (Not close) 10 tickets from inactive devs (can be used towards DevQuest 001, Ticket Massacre)
-- Earn DevQuest 003 (Singles in Your Area)
-- Update 10 achievements towards DevQuest 005 (Trigger Happy)
-- Earn a point towards DevQuest 002 (Retro Renovator) or DevQuest 013 (complete.me)
-- Make a set for DevQuest 016 (Wish This Set)
+[DQ6](#_006-the-unwanted), [DQ19](#_019-wheel-of-genres) and [DQ23](#_023-well-of-wishes) use wheels to give random goals. You are allowed to spin again to change your random goal **three months** after spinning. The first and second spins for each quest are free. If you want to keep on spinning, you will need to earn a new respin token by doing one of the following task:
+- Resolve (Not close) 10 tickets from inactive devs (can be used towards [DQ1](#_001-ticket-massacre) Ticket Massacre)
+- Earn [DQ3](#_003-singles-in-your-area) Singles in Your Area
+- Update 10 achievements towards [DQ5](#_005-trigger-happy) Trigger Happy
+- Earn a point towards [DQ2](#_002-retro-renovator) Retro Renovator or [DQ13](#_013-complete-me) complete.me
+- Make a set for [DQ16](#_016-wish-this-set) Wish This Set
+  
+Refreshing your spin this way can only be done while your spin is used up. For example, you cannot use an old Wish This Set game you made prior to spinning.
 
 ## Suggestions
 

--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -44,7 +44,8 @@ Legacy quests ([DQ4](#004-veteran-developer), [DQ15](#015-console-conqueror) and
 1. Falsifying ticket closures will result in disqualification.
 2. The following do not count toward the total: Network issues, tickets for achievements you developed, tickets you opened, tickets closed on behalf of Junior Developers, and tickets closed as a result of ticket spamming.
 3. Tickets for users banned from development count for double credit.
-4. Up to 10 "unsupported core/emulator" tickets may be used across DQ1 and its sequels. If you have closed 10 in this fashion, no more of this type shall count. The DQ Team shall highlight these tickets using purple on the tracking sheet.
+4. Tickets resolved as part of another maintenance quest such as DQ2 and full dust-offs for DQ22 cannot be used for DQ1.
+5. Up to 10 "unsupported core/emulator" tickets may be used across DQ1 and its sequels. If you have closed 10 in this fashion, no more of this type shall count. The DQ Team shall highlight these tickets using purple on the tracking sheet.
 
 ### 002 [Retro Renovator](https://retroachievements.org/game/15957)
 

--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -80,8 +80,9 @@ Legacy quests ([DQ4](#004-veteran-developer), [DQ15](#015-console-conqueror) and
 
 ![DQ004](https://retroachievements.org/Images/069722.png)
 
-**Type**: Legacy 
-**Goal**: Complete a set of special goals
+**Type**: Legacy  
+**Goal**: Complete a set of special goals  
+**Opt-in**: Request a code review for one your set for 6. below
 
 1. Has published at least 1000 achievements and worked on at least 25 sets as the sole or majority developer.
 2. Has created achievements for at least ten different system IDs.
@@ -276,15 +277,12 @@ An English release is considered a game released in English in US, Canada, UK, o
 
 ![DQ015](https://retroachievements.org/Images/068013.png)
 
-**Type**: Legacy
+**Type**: Legacy  
 **Goal**: Publish a set for every supported system on RetroAchievements  
+**Opt-in**: Develop sets for 10 supported systems and request tracking by contacting the team
 
 :::info Ever-Growing
 Each system ID will have an achievement associated with it. Newly supported system IDs means new achievements!
-:::
-
-::: warning Opt-In Quest
-You must have developed sets for 10 or more supported systems before opt-in. Opt-In to this quest by notifying us on [`#devquest`](https://discord.com/channels/310192285306454017/310195377993416714) channel on Discord or sending a message to the DevQuest account
 :::
 
 1. Meme sets may not be counted at the discretion of the DevQuest Team.
@@ -356,10 +354,7 @@ You must have developed sets for 10 or more supported systems before opt-in. Opt
 
 **Type**: Legacy  
 **Goal**: Publish a set for every genre!  
-
-::: warning Opt-In Quest
-You must have made sets for at least 5 genres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started
-:::
+**Opt-in**: Publish sets for games of 5 different genres, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to the team
 
 1. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
 2. Genres used for this quest are the main Genre hubs. We'll contact you to ask which genre is preferred.
@@ -374,12 +369,9 @@ You must have made sets for at least 5 genres before opt-in. To opt-in, make a c
 
 ![DQ020S](https://retroachievements.org/Images/083452.png)
 
-**Type**: Legacy 
+**Type**: Legacy  
 **Goal**: Publish a set for every subgenre!  
-
-::: warning Opt-In Quest
-You must have made sets for at least 15 subgenres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started. You may use the same sheet to opt in to this and to DevQuest 020.
-:::
+**Opt-in**: Publish sets for games of 15 different subgenres, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to the team. Typically handled together with DQ20 Genre Conqueror
 
 1. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
 2. Genres used for this quest are the Subgenre hubs.

--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -9,8 +9,9 @@ Outside exceptions explicitely written in the individual quest rules, quests of 
 - DevQuests are not available for Junior Developers.
 - To be awarded credit towards a quest, ping the team via a Discord ping in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002) or via [site message](https://retroachievements.org/messages/create?to=DevQuest) within one week of completion, with a link to the appropriate achievement page.
 - Collaborations and subsets are not allowed by default.
+- If you are working on a set and it becomes eligible to a DevQuest, it cannot be used if 50% of the work is already done. This can happen when new quests are introduced, when a set receives enough requests to be eligible for [DQ7](#_007-most-wanted) or when a set is featured in Wish This Set, making it eligible for [DQ16](#_016-wish-this-set). If this happens while you are *less* than halfway done, please reach out to the team to confirm eligibility.
 
-Quest type specific rules:
+Type specific rules:
 
 **Set-Creation**
 - Making a set can only contribute to a single quest. For example, if you make a set for a Japan-exclusive game with a female protagonist that was featured on Wish This Set, you have to choose between [DQ8](#_008-world-traveler), [DQ16](#_016-wish-this-set) and [DQ24](#_024-she-s-got-this), you don't get all three.
@@ -42,9 +43,8 @@ Legacy quests ([DQ4](#_004-veteran-developer), [DQ15](#_015-console-conqueror) a
 
 1. Falsifying ticket closures will result in disqualification.
 2. The following do not count toward the total: Network issues, tickets for achievements you developed, tickets you opened, tickets closed on behalf of Junior Developers, and tickets closed as a result of ticket spamming.
-3. May not overlap with DevQuest 002 or with any completion requirements for DevQuest 013.
-4. Tickets for users banned from development count for double credit.
-5. Up to 10 "unsupported core/emulator" tickets may be used across DQ1 and its sequels. If you have closed 10 in this fashion, no more of this type shall count. The DQ Team shall highlight these tickets using purple on the tracking sheet.
+3. Tickets for users banned from development count for double credit.
+4. Up to 10 "unsupported core/emulator" tickets may be used across DQ1 and its sequels. If you have closed 10 in this fashion, no more of this type shall count. The DQ Team shall highlight these tickets using purple on the tracking sheet.
 
 ### 002 [Retro Renovator](https://retroachievements.org/game/15957)
 
@@ -80,10 +80,8 @@ Legacy quests ([DQ4](#_004-veteran-developer), [DQ15](#_015-console-conqueror) a
 
 ![DQ004](https://retroachievements.org/Images/069722.png)
 
-**Type**: Special  
-**Goal**: Complete a set of special goals  
-**Repeatable**: No  
-**RetroActive!**
+**Type**: Legacy 
+**Goal**: Complete a set of special goals
 
 1. Has published at least 1000 achievements and worked on at least 25 sets as the sole or majority developer.
 2. Has created achievements for at least ten different system IDs.
@@ -164,8 +162,7 @@ No hacks or homebrew unless those are the only types of games left without sets.
 At the time you claim the set, it must be in Most Wanted section of the latest issue of RANews.
 :::
 
-1. If you already have one claimed when the game becomes eligible, you must be under 50% progress for it to count. Please reach out to the team to confirm eligibility when that happens.
-2. Any games listed in the console-specific bonus section in RANews will only be eligible to be claimed in the month it was featured in, but the set doesn't need to be released in the same month.
+1. Any games listed in the console-specific bonus section in RANews will only be eligible to be claimed in the month it was featured in, but the set doesn't need to be released in the same month.
 
 ### 008 [World Traveler](https://retroachievements.org/game/15918)
 
@@ -179,13 +176,11 @@ At the time you claim the set, it must be in Most Wanted section of the latest i
 An English release is considered a game released in English in US, Canada, UK, or AU.<br>1. All claims intended for this quest must follow normal procedure.
 :::
 
-1. All claims intended for this quest must follow normal procedure.
-2. They must be full sets. Fodder for the Progression Only hub won't count.
-3. Sets intended for World Traveler do not stack with other quests based around developing new content.
-4. English translation patches will not disqualify a game from this quest.
-5. Hacks and homebrew do not count towards the quest. Unlicensed titles may count as long as they aren't blatant bootleg ports or hacks of another game. If you're unsure if a game is valid, ask!
-6. If a game was released in English on a system, but was ported to another system with no English version, half credit may be granted for the port on the system that has no English release.
-7. Games that only released in English on unsupported systems will receive full credit.
+1. They must be full sets. Fodder for the Progression Only hub won't count.
+2. English translation patches will not disqualify a game from this quest.
+3. Hacks and homebrew do not count towards the quest. Unlicensed titles may count as long as they aren't blatant bootleg ports or hacks of another game. If you're unsure if a game is valid, ask!
+4. If a game was released in English on a system, but was ported to another system with no English version, half credit may be granted for the port on the system that has no English release.
+5. Games that only released in English on unsupported systems will receive full credit.
 
 ### 009 [Launch Party!](https://retroachievements.org/game/15937)
 
@@ -200,7 +195,7 @@ An English release is considered a game released in English in US, Canada, UK, o
 
 #### Current Launch Party Promotion Windows:
 
-- There are currently no eligible systems
+- Nintendo Wii
 
 ### 010 [It Takes Two](https://retroachievements.org/game/15939)
 
@@ -210,7 +205,7 @@ An English release is considered a game released in English in US, Canada, UK, o
 **Goal**: Join forces with other developers to publish two collaboration sets  
 **Repeatable**: No
 
-1. Set must have a fair share of the work done by each dev - For example, sets with extreme splits like 80%/20% would not allow credit.
+1. Set must have a fair share of the work done by each dev - for example, sets with extreme splits like 80%/20% would not allow credit.
 2. Must be a full set covering every aspect of the game.
 3. Each Dev must publish at least 20 achievements each.
 
@@ -226,11 +221,10 @@ An English release is considered a game released in English in US, Canada, UK, o
 **Goal**: Develop a set for the Sega Genesis/Mega Drive to celebrate the anniversary of RA's first achievement  
 **Repeatable**: No
 
-1. All claims intended for this quest must follow normal procedure.
-2. Must be full sets or a major/significant revision.
-3. Sega CD and Sega 32X games are not eligible.
-4. No prototypes or hacks.
-5. Collaborations are allowed so long as the work is visibly split.
+1. Must be full sets or a major/significant revision.
+2. Sega CD and Sega 32X games are not eligible.
+3. No prototypes or hacks.
+4. Collaborations are allowed so long as the work is visibly split.
 
 ### 012 [Hacker's Habit](https://retroachievements.org/game/672), [Hack at it Again](https://retroachievements.org/game/32908)
 
@@ -272,7 +266,7 @@ An English release is considered a game released in English in US, Canada, UK, o
 2. Try to cover leaderboards that make sense for the game. Some examples:
    - For Arcade-type games it is fine to just add High Score leaderboards, possibly highest in a single life
    - For Racing games time trials for tracks are pretty standard
-   - Speedruns for Platformers
+   - Speedruns for platformers
    - Minigames that track high scores or time are good candidates
    - And so on. Reach out if you have any questions about a specific game
 3. You can do your own sets for half-credit as long as they were published prior to this DevQuest (2022-03-02).
@@ -282,10 +276,8 @@ An English release is considered a game released in English in US, Canada, UK, o
 
 ![DQ015](https://retroachievements.org/Images/068013.png)
 
-**Type**: Special  
+**Type**: Legacy
 **Goal**: Publish a set for every supported system on RetroAchievements  
-**Repeatable**: No  
-**RetroActive!**
 
 :::info Ever-Growing
 Each system ID will have an achievement associated with it. Newly supported system IDs means new achievements!
@@ -337,7 +329,7 @@ You must have developed sets for 10 or more supported systems before opt-in. Opt
 ![DQ018](https://retroachievements.org/Images/073716.png)
 
 **Type**: Set Creation  
-**Goal**: Publish 2 Subsets  
+**Goal**: Publish 2 subsets  
 **Repeatable**: No
 
 1. Read through [Subsets](/guidelines/content/subsets) document to learn more about subsets.
@@ -363,10 +355,8 @@ You must have developed sets for 10 or more supported systems before opt-in. Opt
 
 ![DQ020](https://retroachievements.org/Images/083451.png)
 
-**Type**: Special  
+**Type**: Legacy  
 **Goal**: Publish a set for every genre!  
-**Repeatable**: No  
-**RetroActive!**
 
 ::: warning Opt-In Quest
 You must have made sets for at least 5 genres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started
@@ -386,10 +376,8 @@ You must have made sets for at least 5 genres before opt-in. To opt-in, make a c
 
 ![DQ020S](https://retroachievements.org/Images/083452.png)
 
-**Type**: Special  
+**Type**: Legacy 
 **Goal**: Publish a set for every subgenre!  
-**Repeatable**: No  
-**RetroActive!**
 
 ::: warning Opt-In Quest
 You must have made sets for at least 15 subgenres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started. You may use the same sheet to opt in to this and to DevQuest 020.
@@ -483,7 +471,7 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
 6. Each point of credit (equivalent to one set) must have a different female character as the protagonist (or different ensemble of female characters)
 
 ## Wheel Spin DevQuest Rules
-[DQ6](#_006-the-unwanted), [DQ19](#_019-wheel-of-genres) and [DQ23](#_023-well-of-wishes) use wheels to give random goals. You are allowed to spin again to change your random goal **three months** after spinning. The first and second spins for each quest are free. If you want to keep on spinning, you will need to earn a new respin token by doing one of the following task:
+[DQ6](#_006-the-unwanted), [DQ19](#_019-wheel-of-genres) and [DQ23](#_023-well-of-wishes) use wheels to give random goals. You are allowed to spin again to change your random goal **three months** after spinning. The first and second spins for each quest are free. If you want to keep on spinning, you will need to earn a new respin token by doing one of the following tasks:
 - Resolve (Not close) 10 tickets from inactive devs (can be used towards [DQ1](#_001-ticket-massacre) Ticket Massacre)
 - Earn [DQ3](#_003-singles-in-your-area) Singles in Your Area
 - Update 10 achievements towards [DQ5](#_005-trigger-happy) Trigger Happy
@@ -492,8 +480,9 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
   
 Refreshing your spin this way can only be done while your spin is used up. For example, you cannot use an old Wish This Set game you made prior to spinning.
 
-## Suggestions
+## New DevQuests and suggestions
 
+- New quests will be available periodically. There is no fixed schedule for these.
 - If you have suggestions for a DevQuest, send a message to the DevQuest account with the following info:
   - **Quest Name**
   - **Award Type** - If there is one specific goal then you would want a badge-based award. If there are multiple goals then you would want an achievement-based award.

--- a/docs/developer-docs/devquests.md
+++ b/docs/developer-docs/devquests.md
@@ -9,25 +9,25 @@ Outside exceptions explicitely written in the individual quest rules, quests of 
 - DevQuests are not available for Junior Developers.
 - To be awarded credit towards a quest, ping the team via a Discord ping in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002) or via [site message](https://retroachievements.org/messages/create?to=DevQuest) within one week of completion, with a link to the appropriate achievement page.
 - Collaborations and subsets are not allowed by default.
-- If you are working on a set and it becomes eligible to a DevQuest, it cannot be used if 50% of the work is already done. This can happen when new quests are introduced, when a set receives enough requests to be eligible for [DQ7](#_007-most-wanted) or when a set is featured in Wish This Set, making it eligible for [DQ16](#_016-wish-this-set). If this happens while you are *less* than halfway done, please reach out to the team to confirm eligibility.
+- If you are working on a set and it becomes eligible to a DevQuest, it cannot be used if 50% of the work is already done. This can happen when new quests are introduced, when a set receives enough requests to be eligible for [DQ7](#007-most-wanted) or when a set is featured in Wish This Set, making it eligible for [DQ16](#016-wish-this-set). If this happens while you are *less* than halfway done, please reach out to the team to confirm eligibility.
 
 Type specific rules:
 
 **Set-Creation**
-- Making a set can only contribute to a single quest. For example, if you make a set for a Japan-exclusive game with a female protagonist that was featured on Wish This Set, you have to choose between [DQ8](#_008-world-traveler), [DQ16](#_016-wish-this-set) and [DQ24](#_024-she-s-got-this), you don't get all three.
+- Making a set can only contribute to a single quest. For example, if you make a set for a Japan-exclusive game with a female protagonist that was featured on Wish This Set, you have to choose between [DQ8](#008-world-traveler), [DQ16](#016-wish-this-set) and [DQ24](#024-she-s-got-this), you don't get all three.
 - Standard set quality or better is expected for DevQuest sets. If a set appears to be of insufficient effort, it may be rejected at the DevQuest team's discretion. Rich Presence is required for DevQuest sets. The DevQuest team is happy to suggest improvements for qualification.
 
 **Maintenance**
 - You cannot be an original author on the set being maintained.
 - General revision rules apply: contact the active authors on sets whose content you will update or add to. Moreover, discussions, dev votes and revision claims are required when adding new achievements to a set.
-- Every action can only contribute to a single quest. For example, if you repair a set for [DQ2](#_002-retro-renovator), resolving tickets is part of that task, so these tickets cannot be tallied up towards [DQ1](#_001-ticket-massacre).  However, some sets can benefit from different independant actions in a way that yields credits towards multiple DevQuests. If you add a rich presence, leaderboards and revise a set to cover content that was missing before, you could get credit for DQ13, DQ14 and DQ22.
-- For revision quests ([DQ2](#_002-retro-renovator), [DQ13](#_013-complete-me) and [DQ22](#_022-this-belonged-in-a-museum) Dust-offs), the game needs to be in the approved list. You may propose games you feel should qualify prior to working on them and the team will determine if it fits the quest. While [DQ13](#_013-complete-me) credit can sometimes be granted along [DQ2](#_002-retro-renovator) or [DQ22](#_022-this-belonged-in-a-museum), this is up to a team vote and should only be allowed when both the current content and missing content require significant work.
+- Every action can only contribute to a single quest. For example, if you repair a set for [DQ2](#002-retro-renovator), resolving tickets is part of that task, so these tickets cannot be tallied up towards [DQ1](#001-ticket-massacre).  However, some sets can benefit from different independant actions in a way that yields credits towards multiple DevQuests. If you add a rich presence, leaderboards and revise a set to cover content that was missing before, you could get credit for DQ13, DQ14 and DQ22.
+- For revision quests ([DQ2](#002-retro-renovator), [DQ13](#013-complete-me) and [DQ22](#022-this-belonged-in-a-museum) Dust-offs), the game needs to be in the approved list. You may propose games you feel should qualify prior to working on them and the team will determine if it fits the quest. While [DQ13](#013-complete-me) credit can sometimes be granted along [DQ2](#_002-retro-renovator) or [DQ22](#022-this-belonged-in-a-museum), this is up to a team vote and should only be allowed when both the current content and missing content require significant work.
 - When you update the logic of any asset, keep a backup of the old logic posted in the game's official forum for reference.
-- For miscellaneous maintenance quests ([DQ1](#_001-ticket-massacre), [DQ3](#_003-singles-in-your-area), [DQ5](#_005-trigger-happy) and [DQ14](#_014-laudable-leaderboards)), create a column in the DevQuest Remastered sheet to the left of completed entries and fill it in as you work. Contact the DevQuest team for review only after you have completed the quest. For quests that can be repeated, one row of the column will be for which badge number you are working towards.
+- For miscellaneous maintenance quests ([DQ1](#_001-ticket-massacre), [DQ3](#003-singles-in-your-area), [DQ5](#005-trigger-happy) and [DQ14](#014-laudable-leaderboards)), create a column in the DevQuest Remastered sheet to the left of completed entries and fill it in as you work. Contact the DevQuest team for review only after you have completed the quest. For quests that can be repeated, one row of the column will be for which badge number you are working towards.
 
 **Legacy**
 
-Legacy quests ([DQ4](#_004-veteran-developer), [DQ15](#_015-console-conqueror) and [DQ20](#_020-genre-conqueror)) are fully retroactive and are awarded for having an extensive and wide portfolio as a developer.
+Legacy quests ([DQ4](#004-veteran-developer), [DQ15](#015-console-conqueror) and [DQ20](#020-genre-conqueror)) are fully retroactive and are awarded for having an extensive and wide portfolio as a developer.
 - You may request to be tracked for these after reaching some minimum treshold as determined in the rules of each individual quests.
 - Following that first tracking request, updates are made in sweeps periodically; this means you don't have to (and shouldn't) ping the team every time you complete a new set that adds to your portfolio. Every couple months, the dev responsible for the sweeps for that particular quest will update the status of everyone being tracked and announce the progress in [`#devquest`](https://discord.com/channels/310192285306454017/842845740078334002).
 
@@ -127,7 +127,6 @@ A constantly evolving toolkit means that these requirements are subject to chang
 - Atari Lynx
 - Neo Geo Pocket/Neo Geo Pocket Color
 - Atari Jaguar
-- MSX/MSX2
 - Apple II
 - 3DO Interactive Multiplayer
 - ColecoVision
@@ -259,7 +258,7 @@ An English release is considered a game released in English in US, Canada, UK, o
 ![DQ014](https://media.retroachievements.org/Images/110735.png)
 
 **Type**: Maintenance  
-**Goal**: Create leaderboards for 10 games that currently do not have any  
+**Goal**: Create leaderboards for 10 games that currently are lacking them
 **Repeatable**: No
 
 1. Cover different game modes/difficulties when applicable.
@@ -270,7 +269,8 @@ An English release is considered a game released in English in US, Canada, UK, o
    - Minigames that track high scores or time are good candidates
    - And so on. Reach out if you have any questions about a specific game
 3. You can do your own sets for half-credit as long as they were published prior to this DevQuest (2022-03-02).
-4. You must leave comments on set page for what you added for log purposes
+4. You must leave comments on set page for what you added for log purposes.
+5. Typically covers sets without any leaderboards, but if a set has only a couple leaderboards and is clearly missing some that should be there, it is also eligible.
 
 ### 015 [Console Conqueror](https://retroachievements.org/game/809)
 
@@ -287,12 +287,11 @@ Each system ID will have an achievement associated with it. Newly supported syst
 You must have developed sets for 10 or more supported systems before opt-in. Opt-In to this quest by notifying us on [`#devquest`](https://discord.com/channels/310192285306454017/310195377993416714) channel on Discord or sending a message to the DevQuest account
 :::
 
-1. This quest is awarded in sweeps; do not ping claims or completions. Any set will be counted as long as it meets the requirements, even if used for another DevQuest or if it was made while a Jr. Dev.
-2. Meme sets may not be counted at the discretion of the DevQuest Team.
-3. Doing the same kind of set (e.g. all Flappy Bird clones) will only be counted towards one system.
-4. The only requirement for an unlock is that you are the sole or majority developer of a set on that system ID. Collaborations require at least 20 achievements made.
-5. For the more dire systems, specific requirements are in the achievements themselves.
-6. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
+1. Meme sets may not be counted at the discretion of the DevQuest Team.
+2. Doing the same kind of set (e.g. all Flappy Bird clones) will only be counted towards one system.
+3. The only requirement for an unlock is that you are the sole or majority developer of a set on that system ID. Collaborations require at least 20 achievements made.
+4. For the more dire systems, specific requirements are in the achievements themselves.
+5. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
 
 ### 016 [Wish This Set](https://retroachievements.org/game/2962)
 
@@ -362,15 +361,14 @@ You must have developed sets for 10 or more supported systems before opt-in. Opt
 You must have made sets for at least 5 genres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started
 :::
 
-1. This quest is awarded in sweeps; do not ping claims or completions. Any set will count as long as it meets the requirements, even if used for another DevQuest or if it was made while a Jr. Dev.
-2. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
-3. Genres used for this quest are the main Genre hubs. We'll contact you to ask which genre is preferred.
-4. If a set belongs to multiple top-level genres, we will ask you which genre to count for that set; if later on you do that same genre, you may ask us to reassign the set to the other genre.
-5. Please fill out the Genre field in all sets for you wish to be credited and also assign it to the correct hub(s). Sets with unfilled Genre fields will be skipped.
-6. Falsifying a genre or subgenre field will bar you from this DevQuest.
-7. Sole or Majority Dev will be credited. If it is a collaboration, you may also receive credit if you reach 20 achievements, even if not majority dev.
-8. Excluded Genres: Other and Literature.
-9. Added Genre: Party and Minigame subgenres combined as Party or Minigames Genre
+1. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
+2. Genres used for this quest are the main Genre hubs. We'll contact you to ask which genre is preferred.
+3. If a set belongs to multiple top-level genres, we will ask you which genre to count for that set; if later on you do that same genre, you may ask us to reassign the set to the other genre.
+4. Please fill out the Genre field in all sets for you wish to be credited and also assign it to the correct hub(s). Sets with unfilled Genre fields will be skipped.
+5. Falsifying a genre or subgenre field will bar you from this DevQuest.
+6. Sole or Majority Dev will be credited. If it is a collaboration, you may also receive credit if you reach 20 achievements, even if not majority dev.
+7. Excluded Genres: Other and Literature.
+8. Added Genre: Party and Minigame subgenres combined as Party or Minigames Genre
 
 ### 020 Subset [Subgenre Conqueror](https://retroachievements.org/game/25673)
 
@@ -383,15 +381,14 @@ You must have made sets for at least 5 genres before opt-in. To opt-in, make a c
 You must have made sets for at least 15 subgenres before opt-in. To opt-in, make a copy of the opt-in google sheet linked [here](https://docs.google.com/spreadsheets/u/0/d/1rqYm7q1qh0kl-5qln9SdrNnSMSmZ4TBnpxrlx3TOpJw/edit) and submit it to us to get started. You may use the same sheet to opt in to this and to DevQuest 020.
 :::
 
-1. This quest is awarded in sweeps; do not ping claims or completions. Any set will count as long as it meets the requirements, even if used for another DevQuest or if it was made while a Jr. Dev.
-2. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
-3. Genres used for this quest are the Subgenre hubs.
-4. If a set belongs to multiple subgenres, all will count. Exception: Compilations will only count for Subgenre - Compilation.
-5. Please fill out the Genre field in all sets for you wish to be credited and also assign it to the correct hub(s). Sets with unfilled Genre fields will be skipped.
-6. Falsifying a genre or subgenre field will bar you from this DevQuest.
-7. Sole or Majority Dev will be credited. If it is a collaboration, you may also receive credit if you reach 20 achievements, even if not majority dev.
-8. Excluded subgenres: 4X, Pachinko, Specific Extreme Sports subgenres (each will count towards Subgenre - Extreme Sports), subgenres of Board Games and Card Games (Each will count towards their Board Game or Card Game subgenre parent), Literature subgenres.
-9. Subsets will not count unless approved by DevQuest. Ping DevQuest team for approval request.
+1. This DevQuest is 100% retroactive! Potential future revisions of your work will not count against you, so no worries about losing eligibility for an unlock.
+2. Genres used for this quest are the Subgenre hubs.
+3. If a set belongs to multiple subgenres, all will count. Exception: Compilations will only count for Subgenre - Compilation.
+4. Please fill out the Genre field in all sets for you wish to be credited and also assign it to the correct hub(s). Sets with unfilled Genre fields will be skipped.
+5. Falsifying a genre or subgenre field will bar you from this DevQuest.
+6. Sole or Majority Dev will be credited. If it is a collaboration, you may also receive credit if you reach 20 achievements, even if not majority dev.
+7. Excluded subgenres: 4X, Pachinko, Specific Extreme Sports subgenres (each will count towards Subgenre - Extreme Sports), subgenres of Board Games and Card Games (Each will count towards their Board Game or Card Game subgenre parent), Literature subgenres.
+8. Subsets will not count unless approved by DevQuest. Ping DevQuest team for approval request.
 
 ### 021 [Homebrew Heaven](https://retroachievements.org/game/25677)
 
@@ -471,12 +468,12 @@ You must have made sets for at least 15 subgenres before opt-in. To opt-in, make
 6. Each point of credit (equivalent to one set) must have a different female character as the protagonist (or different ensemble of female characters)
 
 ## Wheel Spin DevQuest Rules
-[DQ6](#_006-the-unwanted), [DQ19](#_019-wheel-of-genres) and [DQ23](#_023-well-of-wishes) use wheels to give random goals. You are allowed to spin again to change your random goal **three months** after spinning. The first and second spins for each quest are free. If you want to keep on spinning, you will need to earn a new respin token by doing one of the following tasks:
-- Resolve (Not close) 10 tickets from inactive devs (can be used towards [DQ1](#_001-ticket-massacre) Ticket Massacre)
-- Earn [DQ3](#_003-singles-in-your-area) Singles in Your Area
-- Update 10 achievements towards [DQ5](#_005-trigger-happy) Trigger Happy
-- Earn a point towards [DQ2](#_002-retro-renovator) Retro Renovator or [DQ13](#_013-complete-me) complete.me
-- Make a set for [DQ16](#_016-wish-this-set) Wish This Set
+[DQ6](#006-the-unwanted), [DQ19](#019-wheel-of-genres) and [DQ23](#023-well-of-wishes) use wheels to give random goals. You are allowed to spin again to change your random goal **three months** after spinning. The first and second spins for each quest are free. If you want to keep on spinning, you will need to earn a new respin token by doing one of the following tasks:
+- Resolve (Not close) 10 tickets from inactive devs (can be used towards [DQ1](#001-ticket-massacre) Ticket Massacre)
+- Earn [DQ3](#003-singles-in-your-area) Singles in Your Area
+- Update 10 achievements towards [DQ5](#005-trigger-happy) Trigger Happy
+- Earn a point towards [DQ2](#002-retro-renovator) Retro Renovator or [DQ13](#013-complete-me) complete.me
+- Make a set for [DQ16](#016-wish-this-set) Wish This Set
   
 Refreshing your spin this way can only be done while your spin is used up. For example, you cannot use an old Wish This Set game you made prior to spinning.
 

--- a/docs/general/teams/devquest-team.md
+++ b/docs/general/teams/devquest-team.md
@@ -160,10 +160,11 @@ When the column is complete and a badge is earned, mark the badge row for that c
 
 ### DevQuest 004: Veteran Developer
 
-Generally, you don't have to worry about this one.  If you request access to the Vet Dev tracking sheet (it is a separate document), you can add in the usernames of developers that opt-in so that `tele` will start tracking them.
-
-- Sweeps are performed by `tele`
-- Code Reviews are performed by DevQuest team members who are also Code Review Team members.
+- To opt-in, devs must submit a set they published as sole dev, as a full developer, for review. Sets that already were reviewed in jr, or collaborations where the separation of work is not crystal clear are not allowed.
+- Add the user to the DQ4 sheet and fill in the first 6 columns.
+- Adding the set to the Vet Dev Review sheet must be done by a Code Reviewer that is also member of the DevQuest team, but any code reviewer can review the set.
+- If you did not make a review, don't touch the Vet Review or 75% of toolkit column. The code reviewer will do that.
+- No need to update values in the first 6 columns once they show up as green. The appropriate columns on the right will show up as yellow so you can award the appropriate "achievements" in the DQ4 event, and check them once awarded as usual.
 
 ### DevQuest 005: Trigger Happy
 


### PR DESCRIPTION
Changelog:

- General clarification of rules
- Adoption of the "single action can contribute to a single quest but a set may benefit from independant action giving credits to different DQs" as a general rule. Remove individual DQ rules on that subject as they are now redundant and often were a bit ambiguous
- Introduction of the Legacy quest type (DQ4, DQ15 and DQ20 at the moment) to codify the "fully retro-active, must do x to opt-in" format
- The opt-in for DQ4 is now done by requesting a review for DQ4-VI. Any DQ member can process the other parts of the quest as it is handled in a single sheet like other quests now, and any CR can do vet dev reviews
- Removed MSX/MSX2 from eligible systems for DQ6 The Unwanted as it received enough sets in the last DevJam to surpass 100 sets. Congrats to everyone that worked hard on the jam, showing us that the system is very much Wanted!
- Added Nintendo Wii to eligible systems for DQ9 Launch Party! for the on-going rollout
- DQ14 Laudable Leaderboards has been extended to allow getting credits from adding clearly missing leaderboards to a game even if it already has a couple