### PR TITLE
Minor change to leaderboards.md: Clarification of game speed hint

### DIFF
--- a/docs/developer-docs/leaderboards.md
+++ b/docs/developer-docs/leaderboards.md
@@ -55,7 +55,7 @@ The best place to start is to look at existing leaderboards and break it down to
 
 The **Title/Description** fields are quite obvious.
 
-The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second. (see not below for systems that run at other speeds)
+The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second.
 
 The **Lower Is Better** flag is checked, then the one who makes the shortest time will be the #1.
 

--- a/docs/developer-docs/leaderboards.md
+++ b/docs/developer-docs/leaderboards.md
@@ -55,7 +55,7 @@ The best place to start is to look at existing leaderboards and break it down to
 
 The **Title/Description** fields are quite obvious.
 
-The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second (see note below on [Value Definition](/developer-docs/value-definition) for systems that run at other speeds).
+The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second (see note below on [Value Format](/developer-docs/leaderboards#value-format) for systems that run at other speeds).
 
 The **Lower Is Better** flag is checked, then the one who makes the shortest time will be the #1.
 

--- a/docs/developer-docs/leaderboards.md
+++ b/docs/developer-docs/leaderboards.md
@@ -55,7 +55,7 @@ The best place to start is to look at existing leaderboards and break it down to
 
 The **Title/Description** fields are quite obvious.
 
-The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second.
+The **Type** is "Time (Frames)". The value we're tracking updates once a frame, and the Genesis runs at 60 frames per second (see note below on [Value Definition](/developer-docs/value-definition) for systems that run at other speeds).
 
 The **Lower Is Better** flag is checked, then the one who makes the shortest time will be the #1.
 


### PR DESCRIPTION
**Edit**: Instead of removing the part, I suggest to improve it, see my latest comment below.

Original comment:

---

Remove confusing part of sentence.

I really struggled when reading the part I suggest to remove. What's the meaning of "see not below" - don't look below? Even if only the "not" was misplaced, there is nothing more below on the page about framerates or game speed.

I checked the [Initial commit](https://github.com/RetroAchievements/docs/blob/f7f48cd8661671079b9c6949a8070804d3f6a7bc/archive/Leaderboards.md) where this was added but was not able to find anything related to this.

Furthermore, a search across the RA docs with "framerate", "frame rate" or "game speed" does not return any page with additional information (except maybe for the [`ResetIf` docs](https://docs.retroachievements.org/developer-docs/real-examples/creating-a-timer-with-reset-if-hits-based-on-the-speed-of-the-game.html#creating-a-timer-with-resetif-hits-based-on-the-speed-of-the-game) with a short note on PAL vs. NTSC, but I'm not sure if it's worth linking it).

So my suggestion would be to remove this part of the sentence alltogether.