### PR TITLE
Modifying DSi Specific Tips

### DIFF
--- a/docs/developer-docs/console-specific-tips.md
+++ b/docs/developer-docs/console-specific-tips.md
@@ -137,7 +137,7 @@ Checks if the 8-bit value at 0x18BAB5 is equal to 0x20. This means 0x18BAB5 cont
 - Pointers always start with a `0x02`. For example, a pointer pointing directly to `0x13f944` will be `0x0213f944`.
 - DSi mode can be detected when bit0 & bit1 are 1 at 0x400. This is known to slightly shift memory on some games and so it could be used to protect against the mode if needs be.
 
-## Nintendo DSi (Bizhawk)
+## Nintendo DSi
 
 - **0xfffe00: DSi Mode String** ASCII String that identifies the DSi Game being played. Can be used to check if you are in the game rather than on the DSi home screen, etc.
 


### PR DESCRIPTION
Due to this tip also applying to MelonDS DS and most likely, future DSi Compatible Cores, specifying Bizhawk here seems unnecessary.