### PR TITLE
Add tip to Overly Cumbersome Requirements UWC

### DIFF
--- a/docs/guidelines/content/unwelcome-concepts.md
+++ b/docs/guidelines/content/unwelcome-concepts.md
@@ -118,6 +118,10 @@ When these are acceptable:
 
 Achievements with restrictions or requirements that cannot be fully expressed within the description character limit. A player should be able to view achievement requirements directly within their emulator, without needing to visit the RetroAchievements website.
 
+:::tip APPLIES ONLY TO DESCRIPTIONS
+This unwelcome concept applies only to the description. If a description is clear, but the steps needed to meet the goal of the achievement are tricky, the achievement does *NOT* fall under this category.
+:::
+
 - Comments on the achievement that include additional restrictions or requirements are not allowed.
 - Required external resources like pastebin links are not allowed.
 - Overly abbreviating a description to fit, such that the description cannot be understood easily, is not allowed.


### PR DESCRIPTION
We get a lot of reports for achievements like "Get the MacGuffin without eating cheese" where the reporter flags this UWC with a comment like, "In order to accomplish doing this without getting cheese, the player has to do <*big list of steps they didn't find to be obvious*>'."

This is an attempt to mitigate that kind of thing.