### PR TITLE
Fix 4 typos in developer/guideline docs

### DIFF
--- a/docs/developer-docs/achievement-templates.md
+++ b/docs/developer-docs/achievement-templates.md
@@ -230,7 +230,7 @@ In this example we want to detect a value changing from `V1` to `V2` ten times:
 
 Conditional resets can be used for many things.
 
-Lets say you want to have a reset if a player enters a certain X and Y zone of a level:
+Let's say you want to have a reset if a player enters a certain X and Y zone of a level:
 
 **CORE**
 

--- a/docs/developer-docs/alt-groups.md
+++ b/docs/developer-docs/alt-groups.md
@@ -5,7 +5,7 @@ description: Learn how to use Alt Groups to create alternative requirements for 
 
 # Alt Groups
 
-Achievements can have groups added to them that allow for alternative requirements to unlock an achievement. These are called _Alt Groups_,
+Achievements can have groups added to them that allow for alternative requirements to unlock an achievement. These are called _Alt Groups_.
 
 When using _Alt groups_, for the achievement to trigger, all the conditions in the _Core group_ MUST be true. And then all the conditions of ANY _Alt group_ must be true. In other words, each _Alt group_ uses `OR` logic.
 

--- a/docs/developer-docs/alt-groups.md
+++ b/docs/developer-docs/alt-groups.md
@@ -11,7 +11,7 @@ When using _Alt groups_, for the achievement to trigger, all the conditions in t
 
 ## Example
 
-In this dummy example for Contra (NES) the achievement requires, "While on stage look up or crouch." Lets look at what's in the _Core group_ and in the _Alt groups_:
+In this dummy example for Contra (NES) the achievement requires, "While on stage look up or crouch." Let's look at what's in the _Core group_ and in the _Alt groups_:
 
 ![Alt Groups: Core](/alt-groups-core.png)
 In the core group: `0x18 = 5`. This checks that the player is on stage.

--- a/docs/guidelines/content/hash-labels.md
+++ b/docs/guidelines/content/hash-labels.md
@@ -14,7 +14,7 @@ Every ROM that is linked to an achievement set must be clearly identified and la
 - RA Hash: Check [Game Identification](/developer-docs/game-identification) to learn more about these. These appear in `Manage Hashes` automatically.
 - File Name - File name should be entered as the description. These are typically automatic, but may need some adjustments.
 - Labels - You can use the labels listed below by using the filename of the image (no extension).
-- Patch URL - Link to an either .zip or .7z file in the [RAPatches](https://github.com/RetroAchievements/RAPatches) GitHub repository. 
+- Patch URL - Link to either a .zip or .7z file in the [RAPatches](https://github.com/RetroAchievements/RAPatches) GitHub repository. 
 - Resource Page URL - Link to a specific No Intro, Redump, RHDN, SMWCentral, itch.io, etc. page.
 
 ## Images


### PR DESCRIPTION
As the title says, this PR fixes 4 typos in 3 files:
* docs/developer-docs/achievement-templates.md
* docs/developer-docs/alt-groups.md
* docs/guidelines/content/hash-labels.md

I spotted those by chance as I was reading the docs.