### PR TITLE
Remove remarks about "not mandatory for junior-devs"

### DIFF
--- a/docs/developer-docs/flags/addhits-subhits.md
+++ b/docs/developer-docs/flags/addhits-subhits.md
@@ -5,8 +5,6 @@ description: Master the use of AddHits and SubHits flags to manage hit counts in
 
 # `AddHits` and `SubHits`
 
-**NOTE**: This technique is not needed for simple games, so it is not mandatory for jr-devs.
-
 `AddHits` and `SubHits` can be chosen in the Flag column of the Achievement Editor.
 
 The `AddHits`/`SubHits` conditions do not have to be true for the achievement to trigger. They modify the [hit count](/developer-docs/hit-counts) of another condition, which does have to be true for the achievement to trigger. The sequence of conditions is referred to as a `AddHits` chain (even if it contains `SubHits`).

--- a/docs/developer-docs/flags/addsource.md
+++ b/docs/developer-docs/flags/addsource.md
@@ -5,9 +5,7 @@ description: Learn how to effectively use the AddSource flag to manage accumulat
 
 # `AddSource`
 
-_**Note**: most likely this technique is not needed for simple games. So, it's not mandatory for jr-devs._
-
-The `AddSource` can be chosen in the Flag column of the Achievement Editor
+The `AddSource` can be chosen in the Flag column of the Achievement Editor.
 
 When a condition has the `AddSource` flag, the value on that memory address is added to the accumulator. When a condition is reached that does not modify the accumulator, the accumulator is added to value of the address on that condition before the comparison is made, and the accumulator will be reset to 0. It may sound a bit confusing, but the example below will clarify how this works:
 

--- a/docs/developer-docs/flags/subsource.md
+++ b/docs/developer-docs/flags/subsource.md
@@ -5,9 +5,7 @@ description: Learn how to effectively use the SubSource flag to subtract values 
 
 # `SubSource`
 
-_**Note**: most likely this technique is not needed for simple games. So, it's not mandatory for jr-devs._
-
-The `SubSource` can be chosen in the Flag column of the Achievement Editor
+The `SubSource` can be chosen in the Flag column of the Achievement Editor.
 
 Works similarly to [`AddSource`](/developer-docs/flags/addsource), but the `SubSource` flag subtracts the calculated value from the accumulator.
 


### PR DESCRIPTION
As discussed in a junior-dev subthread, these remarks are outdated and should be removed.
Discord thread: https://discord.com/channels/310192285306454017/1484025233269719110/1484907519821348905