### PR TITLE
doc(subsets): reflect new challenge subset type

### DIFF
--- a/docs/guidelines/content/subsets.md
+++ b/docs/guidelines/content/subsets.md
@@ -28,7 +28,8 @@ The multiset system uses four technical set types that determine how sets relate
 
 - **Base**: The primary achievement set for a game. This is loaded by default and represents the main content.
 - **Bonus**: Additional achievements linked to a base set. When you load a base set, any associated bonus sets are also available based on your preferences.
-- **Specialty**: These sets still require their own patched ROM, but also load the base set and any bonus sets automatically. These are typically used for challenge runs or alternate game modes.
+- **Challenge**: Like bonus, does not require a patched ROM but is opt-out by default, requiring you to opt-in to play. These are typically used when you play the game in a specific way, like low-level or solo runs.
+- **Specialty**: These sets still require their own patched ROM, but also load the base set and any bonus sets automatically. These are typically used for alternate game modes or challenges that modify the game itself.
 - **Exclusive**: These sets load in isolation and are not compatible with any of the other game's sets.
 
 ### User Preferences

--- a/docs/guidelines/content/subsets.md
+++ b/docs/guidelines/content/subsets.md
@@ -28,7 +28,7 @@ The multiset system uses four technical set types that determine how sets relate
 
 - **Base**: The primary achievement set for a game. This is loaded by default and represents the main content.
 - **Bonus**: Additional achievements linked to a base set. When you load a base set, any associated bonus sets are also available based on your preferences.
-- **Challenge**: Like bonus, does not require a patched ROM but is opt-out by default, requiring you to opt-in to play. These are typically used when you play the game in a specific way, like low-level or solo runs.
+- **Challenge**: Like bonus, does not require a patched ROM but is opt-out by default, requiring you to opt-in to play. These are typically used when you play the game in a specific way, like low-level/single-member party runs in RPGs, beating a game without weapons, or doing as much as you can before a certain story event.
 - **Specialty**: These sets still require their own patched ROM, but also load the base set and any bonus sets automatically. These are typically used for alternate game modes or challenges that modify the game itself.
 - **Exclusive**: These sets load in isolation and are not compatible with any of the other game's sets.
 


### PR DESCRIPTION
Staying on top of new features!

Adds info regarding Challenge subsets based on the info in https://github.com/RetroAchievements/RAWeb/pull/4723

Also changes the wording for speciality to reflect the specific types of challenges that require a patch. I put "challenges that modify the game itself" but I wanted this to word in a way that implies the game is changing instead of just how you play it. Maybe there's a better way to word it.

Draft until the above PR is merged, getting it here to make sure it's good to go first.