### PR TITLE
docs: add a glossary page to describe some common terms

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -64,6 +64,10 @@ function sidebarGeneral(): DefaultTheme.SidebarItem[] {
         //   link: "/general/setup-guide",
         // },
         {
+          text: "Glossary",
+          link: "/general/glossary",
+        },
+        {
           text: "Emulator Support",
           link: "/general/emulator-support-and-issues",
         },

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -78,6 +78,8 @@ A "set" is a collection of achievements for a game.
 
 Game and set are usually used interchangeably, as many games have one base set, but there are a handful of subsets.
 
+See [what is an achievement set?](how-ra-works.md#what-is-an-achievement-set) for more information.
+
 ### Multiset
 
 Multiset is a tool for subsets that allow you to earn achievements towards multiple subsets at once.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -109,8 +109,7 @@ See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Har
 
 ## Standalone
 
-Typically, all games run on an emulator. However, some games run standalone.
-Currently, there are just Terraria and Final Fantasy XI, but more may be added in the future.
+Typically, all games run on an emulator. However, some games run standalone (e.g. Final Fantasy XI and Terraria).
 You'll see these under "Standalone" or "EXE".
 
 Standalone games run as is, without an emulator, and require something else, like a mod, to get you connected to RetroAchievements.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -16,11 +16,31 @@ There are three different types of awards
 * Game Awards – Given for [completing](#completion) or [mastering](#mastery) game sets.
 * Site Awards – Special awards given out for completing certain tasks
 
+## Cheevo
+
+Short for "Achievement".
+
+## Core
+
+A core, also referred to as a libretro core, is a specific emulator used in RetroArch (or RALibretro) to play a particular game.
+
+For example, you might use the DeSmuMe or MelonDS DS core for Nintendo DS games.
+
+You would manage all of this inside RetroArch and download the cores needed for the games there.
+This is why RetroArch is listed as supporting many systems.
+
 ## Completion
 
 Completion is the [softcore](#softcore) version of a [mastery](#mastery).
 
 You earn it for collecting every achievement in a game or [set](#set).
+
+## Developer
+
+Around the site, you'll see "developers" and sets "developed by" users of RetroAchievements.
+These are almost always users of RetroAchievements developing the achievement set, not the game.
+
+Whenever you see someone listed as a "Developer" or "Jr. Developer", they are individuals who develop sets for the site.
 
 ## Event
 
@@ -36,9 +56,15 @@ Collecting every achievement in a [set](#set) in hardcore mode gives you a [mast
 
 See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.
 
+## Juice
+
+Sometimes used as a term for "points" an achievement has.
+
 ## Mastery
 
-When you collect every achievement in a game's set in [Hardcore](#hardcore) mode.
+This is when you collect every achievement in a game's set in [Hardcore](#hardcore) mode.
+
+Mastering a game awards you a [badge](#award-badge) for your profile.
 
 ## RetroPoints
 
@@ -48,7 +74,9 @@ See the [FAQ entry](faq.md#what-are-the-white-points) for more information.
 
 ## Set
 
-A "set" is a collection of achievements for a game, but there may also be one for a subset.
+A "set" is a collection of achievements for a game.
+
+Game and set are usually used interchangeably, as many games have one base set, but there are a handful of subsets.
 
 ### Multiset
 
@@ -71,3 +99,19 @@ See [the dedicated subsets page](../guidelines/content/subsets.md) for more info
 Collecting every achievement in a set, in either hardcore or softcore, gives you a [Completion](#completion) of the game, and a [badge](#award-badge) for your profile.
 
 See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.
+
+## Standalone
+
+Typically, all games run on an emulator. However, some games run standalone.
+Currently, there are just Terraria and Final Fantasy XI, but more may be added in the future.
+You'll see these under "Standalone" or "EXE".
+
+Standalone games run as is, without an emulator, and require something else, like a mod, to get you connected to RetroAchievements.
+
+## Ticket
+
+A ticket is a report of an issue with an achievement. You'll see a button for this on the side of game pages.
+
+You may also see them referred to as "reports" or "issues" with the achievements.
+
+See [how do I report a broken achievement?](faq.md#how-do-i-report-a-broken-achievement) in the FAQ for more information about reporting.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -22,12 +22,14 @@ Short for "Achievement".
 
 ## Core
 
-A core, also referred to as a libretro core, is a specific emulator used in RetroArch (or RALibretro) to play a particular game.
+A core, also referred to as a libretro core, is essentially a program that runs through emulators like RetroArch, RALibretro, and BizHawk to play a particular game.
 
 For example, you might use the DeSmuMe or MelonDS DS core for Nintendo DS games.
 
 You would manage all of this inside RetroArch and download the cores needed for the games there.
 This is why RetroArch is listed as supporting many systems.
+
+On the [Emulator Support](emulator-support-and-issues.md) page, you can see what libretro cores are supported for each system, if applicable.
 
 ## Completion
 
@@ -55,6 +57,13 @@ See [the dedicated page](events.md) for more information and some active events 
 Collecting every achievement in a [set](#set) in hardcore mode gives you a [mastery](#mastery) of the game, and a badge for your profile.
 
 See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.
+
+## Hash
+
+A game hash is a specific version of a particular game.
+This is used to verify your copy of the game to ensure it supports achievements.
+
+See [the relevant FAQ](faq.md#what-is-an-ra-hash) for more information.
 
 ## Mastery
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -11,7 +11,7 @@ Below is a list of terms used around the RetroAchievements site described to hel
 
 Awards, also sometimes referred to as badges, are given for completing various tasks.
 
-There are three different types of awards
+There are three different types of awards:
 * Event Awards – Given for completing [events](events.md).
 * Game Awards – Given for [completing](#completion) or [mastering](#mastery) game sets.
 * Site Awards – Special awards given out for completing certain tasks

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -56,10 +56,6 @@ Collecting every achievement in a [set](#set) in hardcore mode gives you a [mast
 
 See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.
 
-## Juice
-
-Sometimes used as a term for "points" an achievement has.
-
 ## Mastery
 
 This is when you collect every achievement in a game's set in [Hardcore](#hardcore) mode.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -24,7 +24,7 @@ Short for "Achievement".
 
 A core, also referred to as a libretro core, is essentially a program that runs through emulators like RetroArch, RALibretro, and BizHawk to play a particular game.
 
-For example, you might use the DeSmuMe or MelonDS DS core for Nintendo DS games.
+For example, you might use the DeSmuME or melonDS DS core for Nintendo DS games.
 
 You would manage all of this inside RetroArch and download the cores needed for the games there.
 This is why RetroArch is listed as supporting many systems.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -1,0 +1,73 @@
+---
+title: Glossary
+description: Breakdown of terms you might see all around the website
+---
+
+# Glossary
+
+Below is a list of terms used around the RetroAchievements site described to help explain them!
+
+## Award / Badge
+
+Awards, also sometimes referred to as badges, are given for completing various tasks.
+
+There are three different types of awards
+* Event Awards – Given for completing [events](events.md).
+* Game Awards – Given for [completing](#completion) or [mastering](#mastery) game sets.
+* Site Awards – Special awards given out for completing certain tasks
+
+## Completion
+
+Completion is the [softcore](#softcore) version of a [mastery](#mastery).
+
+You earn it for collecting every achievement in a game or [set](#set).
+
+## Event
+
+An event is a set of challenges put on by the community to challenge players into doing various tasks for a badge.
+
+See [the dedicated page](events.md) for more information and some active events you can hop into!
+
+## Hardcore
+
+"Hardcore" is a mode for achievement collecting that disables certain emulator features to simulate playing as you would on a real console.
+
+Collecting every achievement in a [set](#set) in hardcore mode gives you a [mastery](#mastery) of the game, and a badge for your profile.
+
+See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.
+
+## Mastery
+
+When you collect every achievement in a game's set in [Hardcore](#hardcore) mode.
+
+## RetroPoints
+
+The "white points" you see next to the blue normal points. A tooltip describes them as the points adjusted for rarity.
+
+See the [FAQ entry](faq.md#what-are-the-white-points) for more information.
+
+## Set
+
+A "set" is a collection of achievements for a game, but there may also be one for a subset.
+
+### Multiset
+
+Multiset is a tool for subsets that allow you to earn achievements towards multiple subsets at once.
+
+See [the dedicated subsets page](../guidelines/content/subsets.md) for more information.
+
+### Subset
+
+A subset is an additional set for a game, containing additional challenges or requirements that are beyond the main game's set itself.
+
+You can see these by going to a game's page and navigating to the other icons above the achievement list.
+
+See [the dedicated subsets page](../guidelines/content/subsets.md) for more information.
+
+## Softcore
+
+"Softcore" is a mode for achievement collecting that allows you to use all of an emulator's features. 
+
+Collecting every achievement in a set, in either hardcore or softcore, gives you a [Completion](#completion) of the game, and a [badge](#award-badge) for your profile.
+
+See the [FAQ entry](faq.md#what-is-hardcore-mode) for more information about Hardcore/Softcore mode.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -40,11 +40,11 @@ You earn it for collecting every achievement in a game or [set](#set).
 Around the site, you'll see "developers" and sets "developed by" users of RetroAchievements.
 These are almost always users of RetroAchievements developing the achievement set, not the game.
 
-Whenever you see someone listed as a "Developer" or "Jr. Developer", they are individuals who develop sets for the site.
+Whenever you see someone listed as a "Developer" or "Jr. Developer", they are individuals who develop achievement sets for the site.
 
 ## Event
 
-An event is a set of challenges put on by the community to challenge players into doing various tasks for a badge.
+An event is a list of challenges put on by the community to challenge players into doing various tasks for a badge.
 
 See [the dedicated page](events.md) for more information and some active events you can hop into!
 
@@ -72,19 +72,19 @@ See the [FAQ entry](faq.md#what-are-the-white-points) for more information.
 
 A "set" is a collection of achievements for a game.
 
-Game and set are usually used interchangeably, as many games have one base set, but there are a handful of subsets.
+Game and set are usually used interchangeably, as many games have only one achievement set. A game may also have a handful of subsets.
 
 See [what is an achievement set?](how-ra-works.md#what-is-an-achievement-set) for more information.
 
 ### Multiset
 
-Multiset is a tool for subsets that allow you to earn achievements towards multiple subsets at once.
+Multiset is an emulator feature that allows you to earn achievements towards multiple achievement sets for a single game at once.
 
 See [the dedicated subsets page](../guidelines/content/subsets.md) for more information.
 
 ### Subset
 
-A subset is an additional set for a game, containing additional challenges or requirements that are beyond the main game's set itself.
+A subset is an additional set for a game, containing additional challenges or requirements that are beyond the requirements of the game's base set.
 
 You can see these by going to a game's page and navigating to the other icons above the achievement list.
 
@@ -108,7 +108,7 @@ Standalone games run as is, without an emulator, and require something else, lik
 
 ## Ticket
 
-A ticket is a report of an issue with an achievement. You'll see a button for this on the side of game pages.
+A ticket is a bug report for an achievement.
 
 You may also see them referred to as "reports" or "issues" with the achievements.
 


### PR DESCRIPTION
View this PR: https://feat-glossary.chew-ra-docs.pages.dev/general/glossary.html

This adds a simple Glossary page of what are common terms for active RA users but some newcomers may not understand.

This knowledge gap was revealed when a user came in asking what a mastery was. So, I decided to make a page that briefly describes a lot of RA specific terms, with links to more detailed pages if available to go into more detail.

Would appreciate feedback to make sure everything I have is accurate, or if anything needs to be added.