### PR TITLE
Add the AmiArcadia core as supported for A2001, ELEK, and VC4000

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -55,6 +55,7 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 | Name                                                  | Type                | Notes |
 | :---------------------------------------------------- | :------------------ | :---- |
+| **AmiArcadia**                                        | libretro core       |       |
 | **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
 | **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 
@@ -119,6 +120,7 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 | Name                                                  | Type                | Notes |
 | :---------------------------------------------------- | :------------------ | :---- |
+| **AmiArcadia**                                        | libretro core       |       |
 | **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
 | **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 
@@ -211,6 +213,7 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 
 | Name                                                  | Type                | Notes |
 | :---------------------------------------------------- | :------------------ | :---- |
+| **AmiArcadia**                                        | libretro core       |       |
 | **[WinArcadia](https://amigan.1emu.net/releases/)**   | Standalone emulator |       |
 | **[DroidArcadia](https://amigan.1emu.net/releases/)** | Standalone emulator |       |
 


### PR DESCRIPTION
I'd like to propose marking the AmiArcadia core as supported.

I've been able to complete (soft master) the following games without issue using only that core. I did not run into issues with any other games I tried.

Arcadia 2001:
Auto Race - https://retroachievements.org/game/21577
Cat Trax - https://retroachievements.org/game/21585
Route 16 - https://retroachievements.org/game/21608

Elektor TV Games Computer:
Asteroids - https://retroachievements.org/game/22898
Car Race - https://retroachievements.org/game/24684
Catapult - https://retroachievements.org/game/24670
Jackpot - https://retroachievements.org/game/24673

Interton VC 4000:
Boxing Match - https://retroachievements.org/game/21624
Come-Frutas - https://retroachievements.org/game/24635
Laser Attack - https://retroachievements.org/game/21641