### PR TITLE
Update Romulus link in ROM verification section

### DIFF
--- a/docs/guidelines/content/working-with-the-right-rom.md
+++ b/docs/guidelines/content/working-with-the-right-rom.md
@@ -42,7 +42,7 @@ _**Example:** Diddy Kong Racing (USA) (En,Fr) (Rev 1)_
 
 [TOSEC](https://www.tosecdev.org/) is another less restrictive preservation group. Their hashes often will match Redump for discs, but will frequently contain less thoroughly verified dumps. For floppy discs, cassettes, and less well-known systems where No-Intro and/or Redump verification aren't available, TOSEC is a good fallback choice.
 
-You can verify that your ROM checksum matches the databases of No-Intro, Redump, or TOSEC either by using a rom manager with a dat provided by the preferred group or by verifying checksum manually and searching the dat for it in a text editor. Bear in mind that unlike a manual check, the rom manager may be able to skip over external headers to accurately verify integrity. Standard choices are [clrmamepro](https://mamedev.emulab.it/clrmamepro/) and [Romulus](https://romulus.cc/).
+You can verify that your ROM checksum matches the databases of No-Intro, Redump, or TOSEC either by using a rom manager with a dat provided by the preferred group or by verifying checksum manually and searching the dat for it in a text editor. Bear in mind that unlike a manual check, the rom manager may be able to skip over external headers to accurately verify integrity. Standard choices are [clrmamepro](https://mamedev.emulab.it/clrmamepro/) and [Romulus](https://romulus.dats.site/).
 
 ## Preferred Groups Per System
 


### PR DESCRIPTION
The old link leads to spam/fishy websites and should not be promoted. The original link stopped working around end of 2022 according to archive.org (last working link: https://web.archive.org/web/20221001201440/https://romulus.cc/)