### PR TITLE
update supported cores for FDS

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -99,6 +99,17 @@ description: Information about unsupported emulators and cores for RetroAchievem
 
 - ❓ BizHawk core: **ChannelFHawk**
 
+## Famicom Disk System
+
+- ❌ libretro core: **FCEUmm**
+  - Does not expose extra FDS RAM
+- ❌ libretro core: **QuickNES**
+  - Does not emulate the disk system
+- ❌ libretro core: **NEStopia**
+  - Does not expose extra FDS RAM
+- ❓ libretro core: **Emux NES**
+- ❓ libretro core: **fixNES**
+
 ## FM Towns
 
 - ❌ _Not supported_ - needs hashing method and memory map

--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -128,6 +128,13 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 | :----------- | :------------ | :---- |
 | **FreeChaF** | libretro core |       |
 
+### Famicom Disk System
+
+| Name                                                 | Type                | Notes             |
+| :--------------------------------------------------- | :------------------ | :---------------- |
+| **Mesen**                                            | libretro core       | Most recommended. |
+| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                   |
+
 ### Game Boy
 
 | Name                                                         | Type                | Notes                                   |
@@ -260,17 +267,9 @@ BizHawk cores can only be played on [BizHawk](https://tasvideos.org/Bizhawk). Mo
 | :------------------------------------------------------------- | :------------------ | :---------------------------------------- |
 | **FCEUmm**                                                     | libretro core       | Most recommended.                         |
 | **Mesen**                                                      | libretro core       |                                           |
-| **QuickNES**                                                   | libretro core       | Does not emulate the Famicom Disk System. |
+| **QuickNES**                                                   | libretro core       |                                           |
 | **[RANes](https://retroachievements.org/downloads)**           | Standalone emulator |                                           |
 | **[NES RA Adapter](https://github.com/odelot/nes-ra-adapter)** | Console adapter     |                                           |
-
-### NES/Famicom Disk System
-
-| Name                                                 | Type                | Notes             |
-| :--------------------------------------------------- | :------------------ | :---------------- |
-| **FCEUmm**                                           | libretro core       | Most recommended. |
-| **Mesen**                                            | libretro core       |                   |
-| **[RANes](https://retroachievements.org/downloads)** | Standalone emulator |                   |
 
 ### Nintendo 64
 


### PR DESCRIPTION
The FCEUmm core does not expose the extra FDS RAM, so it shouldn't be listed as the most recommended core.

* Changes Mesen to be the most recommended FDS core.
* Removes the "NES /" prefix from the "Famicom Disk System" header and relocates it alphabetically
* Moves FCEUmm from supported to unsupported for FDS (similar to how NEStopia is not supported for NES, but works for games without SRAM, FCEUmm works for FDS games not using the extended RAM).
* Removes the note about FDS support for QuickNES from the NES section.