### PR TITLE
Add a page for DevJam 10: Master System / Game Gear

### DIFF
--- a/docs/developer-docs/devjam.md
+++ b/docs/developer-docs/devjam.md
@@ -53,17 +53,18 @@ A DevJam lasts three months. Some will go on longer if the situation calls for i
 
 Check the links here for console-specific guidelines and info:
 
-| Number |          Time           |                       Console(s)                       | Number of Participants | Sets Promoted |
-| :----: | :---------------------: | :----------------------------------------------------: | :--------------------: | :-----------: |
-|   01   | 2023-07-01 - 2023-09-30 |    [Sega SG-1000](/developer-docs/devjam/1-sg1000)     |           30           |      60       |
-|   02   | 2023-10-01 - 2024-01-31 |     [Sega Saturn](/developer-docs/devjam/2-saturn)     |           28           |      56       |
-|   03   | 2024-02-01 - 2024-04-30 | [PC Engine/PC Engine CD](/developer-docs/devjam/3-pce) |           28           |      60       |
-|   04   | 2024-05-01 - 2024-08-31 |       [Arcade](/developer-docs/devjam/4-arcade)        |           33           |      80       |
-|   05   | 2024-09-01 - 2024-11-30 |    [PC-8001/PC-8801](/developer-docs/devjam/5-pc88)    |           25           |      40       |
-|   06   | 2024-12-01 - 2025-03-16 |      [Apple II](/developer-docs/devjam/6-appleii)      |           20           |      40       |
-|   07   | 2025-04-01 - 2025-06-30 |   [Sega CD/32X](/developer-docs/devjam/7-segacd-32x)   |           27           |      40       |
-|   08   | 2025-07-01 - 2025-09-30 |          [MSX](/developer-docs/devjam/8-msx)           |           26           |      79       |
-|   09   | 2026-02-01 - 2025-04-30 |     [Catch-Up](/developer-docs/devjam/9-catch-up)      |           ??           |      ??       |
+| Number |          Time           |                                 Console(s)                                 | Number of Participants | Sets Promoted |
+| :----: | :---------------------: | :------------------------------------------------------------------------: | :--------------------: | :-----------: |
+|   01   | 2023-07-01 - 2023-09-30 |              [Sega SG-1000](/developer-docs/devjam/1-sg1000)               |           30           |      60       |
+|   02   | 2023-10-01 - 2024-01-31 |               [Sega Saturn](/developer-docs/devjam/2-saturn)               |           28           |      56       |
+|   03   | 2024-02-01 - 2024-04-30 |           [PC Engine/PC Engine CD](/developer-docs/devjam/3-pce)           |           28           |      60       |
+|   04   | 2024-05-01 - 2024-08-31 |                 [Arcade](/developer-docs/devjam/4-arcade)                  |           33           |      80       |
+|   05   | 2024-09-01 - 2024-11-30 |              [PC-8001/PC-8801](/developer-docs/devjam/5-pc88)              |           25           |      40       |
+|   06   | 2024-12-01 - 2025-03-16 |                [Apple II](/developer-docs/devjam/6-appleii)                |           20           |      40       |
+|   07   | 2025-04-01 - 2025-06-30 |             [Sega CD/32X](/developer-docs/devjam/7-segacd-32x)             |           27           |      40       |
+|   08   | 2025-07-01 - 2025-09-30 |                    [MSX](/developer-docs/devjam/8-msx)                     |           26           |      79       |
+|   09   | 2026-02-01 - 2026-04-30 |               [Catch-Up](/developer-docs/devjam/9-catch-up)                |           ??           |      ??       |
+|   10   | 2026-05-01 - 2026-07-31 | [Master System/Game Gear](/developer-docs/devjam/10-mastersystem-gamegear) |           ??           |      ??       |
 
 ## Planned DevJams
 
@@ -71,10 +72,10 @@ Solo Console DevJams:
 
 - 3DO
 - Famicom Disk System
+- Nintendo DS
 
 Multi-Console DevJams:
 
-- Master System | Game Gear
 - Neo Geo Pocket | WonderSwan | Atari Lynx
 - Atari 2600 | Atari 7800 | Atari Jaguar
 - ColecoVision | Intellivision

--- a/docs/developer-docs/devjam/10-mastersystem-gamegear.md
+++ b/docs/developer-docs/devjam/10-mastersystem-gamegear.md
@@ -1,0 +1,44 @@
+# DevJam X (Master System/Game Gear)
+
+[[toc]]
+
+## Time and Duration
+
+- Start Date: 2026-05-01
+- Launch Date: 2026-07-31
+
+## Point System
+
+Max Earnable Points: 6
+
+This table details earnable points for the Master System/Game Gear DevJam:
+
+| Points |                   Set Submission                               |
+| :----: | :------------------------------------------------------------: |
+|   3    |                Licensed Games                                  |
+|   2    |                Homebrews/Hacks                                 |
+|   2    |                Collaborations                                  |
+|   2    |                Late Submissions (Licensed Games)               |
+|   1    |                Late Submissions (Others)                       |
+
+## Quarterly Goals
+
+While the main goal is to promote a bunch of a sets, there are secondary goals that we can work on as a group. If a goal is met, bonus points will be applied _to those who helped reach it_. Goals that are focused on getting the number of sets to a certain number will grant bonus points to everyone who does a set, even after that goal is met. See the Master System / Game Gear goals [here](https://docs.google.com/spreadsheets/d/1EBMW7nO95wvbsOAIfgm2XFnCCez2a14jRfYAnt-uqvo/edit?gid=420135808#gid=420135808).
+
+## Stats
+
+_as of 2026-05-01 (start date)_
+
+- Current number of sets:
+  - Master System: 149
+  - Game Gear: 119
+- Current number of achievements:
+  - Master System: 4,989
+  - Game Gear: 4,021
+
+## See Also
+
+- [Main DevJam Page](/developer-docs/devjam)
+- [DevJam Vol. 1 Event Entry](https://retroachievements.org/game/20000)
+- [DevJam Vol. 2 Event Entry](https://retroachievements.org/game/30000)
+- [DevJam Forum Topic](https://retroachievements.org/viewtopic.php?t=22368)


### PR DESCRIPTION
Adds a new page and updates the main DevJam page to include that.

This PR also fixes a typo with the end date for the Catch-Up DevJam on the main DevJam page, and adds the missing Nintendo DS option to the list of planned Solo Console DevJams.