### PR TITLE
Update Game Info and Hub Guidelines

### DIFF
--- a/docs/guidelines/content/game-info-and-hub-guidelines.md
+++ b/docs/guidelines/content/game-info-and-hub-guidelines.md
@@ -20,7 +20,6 @@ Game info refers to the metadata on a game page, including the game title, relea
 - If there's a conflict between two games with the same title on the same platform, the publisher, developer, or year of release can be added in parentheses to distinguish them. Example: [Renegade (Ocean Software)](https://retroachievements.org/game/26867) and [Renegade (Kuma Computers)](https://retroachievements.org/game/26732).
 - When a regional variation is approved to have a separate page, the region may be added to distinguish it. Example: [Ecco the Dolphin](https://retroachievements.org/game/8) and [Ecco the Dolphin (Japan)](https://retroachievements.org/game/4374).
 - For MSX games that have a different MSX2 version, the latter can have (MSX2) added to the title. Example: [Dragon Quest](https://retroachievements.org/game/16399) and [Dragon Quest (MSX2)](https://retroachievements.org/game/16400).
-- Games for the Famicom Disk System are currently included under NES/Famicom, but it's a convention to add (FDS) to the title. Example: [All Night Nippon Super Mario Bros. (FDS)](https://retroachievements.org/game/12852).
 - Romanization of Japanese titles can be inconsistent. When in doubt, use the most common romanization used by Wikipedia and other sources. Examples: [Yu Yu Hakusho](https://retroachievements.org/hub/7785) instead of "Yuu Yuu Hakusho", [Cho Aniki](https://retroachievements.org/hub/18695) instead of "Chou Aniki", and [Bobobo-bo Bo-bobo](https://retroachievements.org/hub/20736) instead of "Boboboubo Boubobo".
 	- Games in the same series should use the same romanization of the main title.
 
@@ -31,6 +30,7 @@ Game info refers to the metadata on a game page, including the game title, relea
 	- Example: `~Homebrew~ ~Demo~ Bob's Game` instead of `~Demo~ ~Homebrew~ Bob's Game`. The reason for this is that no matter what stage the game is in, it will always be a homebrew or a hack; therefore, those tags should take priority.
 - In cases where a game is unlicensed and is actually just a hack of another game, then `~Hack~` would be used instead of `~Unlicensed~`.
     - Example: Final Fantasy VII on NES, which is a bootleg/pirate release, but it's actually just a hack of Final Fantasy III that was put on a cartridge. So the RA entry would be `~Hack~ Final Fantasy VII`.
+- Hacks of unlicensed or homebrew games can simply be tagged as `~Hack~` instead of `~Unlicensed~ ~Hack~` or `~Homebrew~ ~Hack~`.
 - Some deprecated game pages that remain on the site are prefixed with `~Z~` so they sort to the bottom of lists.
 - Subsets are signified by adding `[Subset - Name of Subset]` after the title.
 
@@ -43,7 +43,8 @@ Game info refers to the metadata on a game page, including the game title, relea
 	- An additional Japanese title may also be added for the kanji/kana title (e.g. ゼルダの伝説). The Japanese release date does not need to be repeated.
 - Bootleg titles should not be added, even if they have a hash linked to the page. For example, [Adventure Island II: Aliens in Paradise](https://retroachievements.org/game/4486) has a bootleg hash called "Super Mario World 7" linked, but it would be strange to display this next to the official titles.
 - Games with fan translation patches may add the translated title. These titles should not include a region or release date. The original, official title should still be used as the canonical title.
-- In some cases, additional titles may be added if they're helpful or commonly used by fans, even if they weren't officially used or don't come from a translation patch. This might include English translations of non-English titles, for example. Like translation patches, these should not include a region or release date, and should not be the canonical title.
+- In some cases, additional titles may be added if they're helpful or commonly used by fans, even if they weren't officially used or don't come from a translation patch. This might include English translations of non-English titles, for example. Like translation patches, these should not include a region or release date, and generally should not be the canonical title.
+	- There can be exceptions where an unofficial title is used as the canonical title if it's very well-known and used by other sources such as Wikipedia. For example, [Fire Emblem: The Blazing Blade](https://retroachievements.org/game/554) was released simply as "Fire Emblem" outside of Japan, but the translation of the Japanese subtitle, "The Blazing Blade", is commonly used to distinguish it within its series and is even used by Wikipedia.
 - If a non-English game received an official English translation many years later, that English title may be used as the canonical title over the original title. Examples: [EarthBound Beginnings](https://retroachievements.org/game/3814) instead of Mother, and [Trials of Mana](https://retroachievements.org/game/1391) instead of Seiken Densetsu 3.
 
 #### Release Dates
@@ -69,7 +70,6 @@ Game info refers to the metadata on a game page, including the game title, relea
 - When a development team or subsidiary is owned by another company, that larger company does not need to be included. For example, [Sonic the Hedgehog](https://retroachievements.org/game/1) has Sonic Team entered and does not include Sega.
 - For hack developers, it's conventional to enter "Hacker - Name of Hacker" as the developer. The [Central - Hacker](https://retroachievements.org/hub/913) hubs will automatically overlay a link into the developer field.
 - Multiple publishers may be entered when they vary by region. This does not need to correspond with the regional versions that are actually linked to the page.
-- Hacks use the publisher field to note the game the hack is based on - for example, "Hack - Super Mario World". [Hacks](https://retroachievements.org/hub/5987) hub links will automatically be overlaid here.
 - If there is no clear publisher, like with many digitally-released homebrew games, the developer can be repeated in the publisher field.
 - Abbreviations like Co, Inc, and Ltd are not included in developer or publisher names.
 
@@ -77,7 +77,7 @@ Game info refers to the metadata on a game page, including the game title, relea
 
 - Multiple genres and subgenres may be entered whenever necessary.
 - Certain genres should not actually be used on game pages - instead, the games should always be sorted into one of their subgenres. This applies to [Genre - Fighting](https://retroachievements.org/hub/8346), [Genre - Platforming](https://retroachievements.org/hub/9120), and [Genre - Shooter](https://retroachievements.org/hub/2656).
-    - This is also preferred for other genres when possible - for example, if a game is in [Subgenre - Turn-based RPG](https://retroachievements.org/hub/5468), it shouldn't also be included in [Genre - Role-Playing Game](https://retroachievements.org/hub/898). But there are unusual cases such as sports RPGs and fishing RPGs that may not fit in a subgenre.
+    - This is also preferred for other genres when possible - for example, if a game is in [Subgenre - Turn-Based RPG](https://retroachievements.org/hub/5468), it shouldn't also be included in [Genre - Role-Playing Game](https://retroachievements.org/hub/898). But there are unusual cases such as sports RPGs and fishing RPGs that may not fit in a subgenre.
 - Refer to the [Genre Definitions](/guidelines/content/genre-definitions) page for more information on genres.
 
 ## Game Images
@@ -103,7 +103,7 @@ Game images are the displayed images on the game page, including the icon (aka m
 
 ### Screenshots
 
-- File size must be under 1 MB to upload.
+- File size must be under 4 MB to upload.
 - English screenshots are encouraged unless they’re from translation patches in which case the original language is preferred.
 - No watermarks are to be present on any images.
 - Some games lack a typical title screen. In these cases, a screenshot of the title during an opening movie or loading screen may be used. If that doesn't exist, an initial menu screen or gameplay screen may be used.
@@ -113,45 +113,88 @@ Game images are the displayed images on the game page, including the icon (aka m
 #### Screenshot Dimensions
 
 - Screenshots must have the same standard dimensions whenever possible.
-- Listed below are the standard image dimensions for each system.
-	- 96x64 - Pokemon Mini (Images are resized by 4x)
-	- 128x64 - Arduboy (Images are resized by 2x)
-	- 160x102 - Atari Lynx
-	- 160x144 - Game Boy, Game Boy Color, Game Gear, Mega Duck
-	- 160x152 - Neo Geo Pocket
-	- 160x160 - WASM-4, Watara Supervision
-	- 160x228 - Atari 2600 (NTSC)
-	- 160x274 - Atari 2600 (PAL)
-	- 160x240 - Nintendo DS, Nintendo DSi
-	- 164x269 - Arcadia 2001, Elektor TV Games Computer, Interton VC 4000 (Taken in Narrow)
-	- 192x272 - Amstrad CPC
-	- 193x240 - Vectrex
-	- 200x234 - VIC-20
-	- 224x144 - WonderSwan
-	- 240x136 - TIC-80
-	- 240x160 - Game Boy Advance
-	- 240x224 - Oric
-	- 256x192 - ColecoVision, Master System, SG-1000, ZX-81
-	- 256x224 - Famicom Disk System, NES/Famicom, Sega CD, SNES/Super Famicom
-	- 256x232 - PC Engine/TurboGrafx-16, PC-FX
-	- 272x240 - MSX
-	- 280x192 - Apple II
-	- 306x192 - Fairchild Channel F
-	- 320x180 - PlayStation Portable
-	- 320x186 - Virtual Boy
-	- 320x200 - Atari ST, Intellivision, PC-8000/8800, Sharp X1
-	- 320x223 - Atari 7800
-	- 320x224 - 32X, Neo Geo CD, Sega Pico
-	- 320x228 - Atari 5200
-	- 320x235 - Magnavox Odyssey 2
-	- 320x240 - 3DO Interactive Multiplayer, Dreamcast, GameCube, Nintendo 64, PlayStation, PlayStation 2, Xbox
-	- 326x240 - Atari Jaguar CD (These get scaled down and are blurry as a result)
-	- 384x280 - Philips CD-i
-	- 672x432 - Thomson TO8
-	- 792x900 - Super Cassette Vision
-	- Game Dependent - Arcade, Atari Jaguar, DOS, Game & Watch, Genesis/Mega Drive, Nokia N-Gage, PC Engine CD, Sharp X68000, Uzebox
-
-	- Todo: Amiga, Cassette Vision, Commodore 64, FM Towns, PC-6000, PC-9800, TI-83, Wii U, Zeebo
+- Listed below are the standard image dimensions for each system. Some systems may differ depending on the game.
+	- 3DO Interactive Multiplayer - 320x240
+	- Amstrad CPC - 192x272, 384x272
+	- Apple II - 280x192, 560x384
+	- Arcade - Game-dependent
+	- Arcadia 2001 - 164x269 (Taken in narrow)
+	- Arduboy - 128x64
+	- Atari 2600 - 160x228 (NTSC), 160x274 (PAL)
+	- Atari 5200 - 320x228, 336x240
+	- Atari 7800 - 320x223, 320x272, 320x240, 160x240
+	- Atari Jaguar - Game-dependent
+	- Atari Jaguar CD - Game-dependent
+	- Atari Lynx - 160x102
+	- Atari ST - 320x200
+	- Bandai WonderSwan - 224x144, 144x224
+	- ColecoVision - 256x192
+	- Commodore 64 - Game-dependent
+	- Commodore Amiga - Game-dependent
+	- Commodore VIC-20 - 200x234
+	- DOS - Game-dependent
+	- Elektor TV Games Computer - 164x269 (Taken in narrow)
+	- Epoch Co. Cassette Vision - 128x192
+	- Epoch Co. Super Cassette Vision - 198x225
+	- Fairchild Channel F - 306x192
+	- Famicom Disk System - 256x224, 256x240
+	- Fujitsu FM Towns - Game-dependent
+	- GCE Vectrex - 193x240, 360x480
+	- Interton VC 4000 - 164x269 (Taken in narrow)
+	- Magnavox Odyssey 2 - 320x235
+	- Mattel Intellivision - 320x200
+	- Mega Duck - 160x144
+	- Microsoft MSX - 272x240
+	- Microsoft Xbox - 320x240
+	- NEC PC Engine CD/TurboGrafx-CD - 256x232, 256x239, 336x239, 512x243
+	- NEC PC Engine/TurboGrafx-16 - 256x232, 256x239, 336x239, 512x243
+	- NEC PC-6000 - Game-dependent
+	- NEC PC-8000/8800 - 320x200
+	- NEC PC-9800 - 640x400
+	- NEC PC-FX - 256x232, 256x240, 341x240
+	- Nintendo 3DS - 400x240, 320x240, 720x480
+	- Nintendo 64 - 320x240
+	- Nintendo DS - 256x384, 256x192
+	- Nintendo DSi - 256x384, 256x192
+	- Nintendo Entertainment System/Famicom - 256x224, 256x240
+	- Nintendo Game & Watch - Game-dependent
+	- Nintendo Game Boy - 160x144
+	- Nintendo Game Boy Advance - 240x160
+	- Nintendo Game Boy Color - 160x144
+	- Nintendo GameCube - 320x240
+	- Nintendo Pokemon Mini - 96x64
+	- Nintendo Virtual Boy - 320x186, 384x224
+	- Nintendo Wii - Game-dependent. Enable widescreen when the game supports it
+	- Nintendo Wii U - 1280x720
+	- Nokia N-Gage - Game-dependent
+	- Philips CD-i - 384x240, 384x280
+	- Sega 32X - 320x224, 256x224, 320x240
+	- Sega CD - 320x224, 256x224, 320x240
+	- Sega Dreamcast - 320x240
+	- Sega Game Gear - 160x144
+	- Sega Genesis/Mega Drive - 320x224, 256x224, 320x240
+	- Sega Master System - 256x192, 256x224, 256x240
+	- Sega Pico - 320x224, 256x224, 320x240
+	- Sega Saturn - 320x224, 352x224, 320x240, 352x240, 320x256, 352x256, 640x224, 704x224, 640x240, 704x240, 640x448, 704x448, 640x480, 704x480
+	- Sega SG-1000 - 256x192
+	- Sharp X1 - 320x200
+	- Sharp X68000 - Game-dependent
+	- Sinclair ZX Spectrum - 320x240
+	- Sinclair ZX81 - 256x192
+	- SNK Neo Geo CD - 320x224
+	- SNK Neo Geo Pocket - 160x152
+	- Sony PlayStation - 320x240, 256x240, 368x240, 512x240, 640x240, 320x480, 256x480, 368x480, 512x480, 640x480, 320x224, 512x268, 320x268
+	- Sony PlayStation 2 - 320x240, 640x448, 640x512, 596x447, 682x512
+	- Sony PlayStation Portable - 320x180, 480x272
+	- Super Nintendo Entertainment System/Famicom - 256x224, 256x240, 512x224
+	- TCS Oric - 240x224
+	- Texas Instruments TI-83 - 96x64
+	- Thomson TO8 - 672x432
+	- TIC-80 - 240x136
+	- Uzebox - Game-dependent
+	- WASM-4 - 160x160
+	- Watara Supervision - 160x160
+	- Zeebo - 800x480
 
 ## Hubs and Similar Games
 
@@ -161,9 +204,10 @@ Hubs are used to categorize game pages in a variety of ways. Links to similar ga
 
 - Developers can reuse a hub from [Meta - Available Hubs](https://retroachievements.org/hub/3029) if any are available. Simply rename the hub and unlink it from the Meta hub.
 - Certain members of the Site Cleanup Team can create new hubs in the management app.
-- [Series](https://retroachievements.org/hub/3), [Publisher](https://retroachievements.org/hub/958), non-homebrew [Developer](https://retroachievements.org/hub/5733), [Hacks](https://retroachievements.org/hub/5987), Series Hacks, [Fangames](https://retroachievements.org/hub/22202), and [Unlicensed series](https://retroachievements.org/hub/5751) hubs should only be made if they include at least 3 games.
+- [Series](https://retroachievements.org/hub/3), [Publisher](https://retroachievements.org/hub/958), non-homebrew [Developer](https://retroachievements.org/hub/5733), [Series Hacks](https://retroachievements.org/hub/5987), [Fangames](https://retroachievements.org/hub/22202), and [Unlicensed Games](https://retroachievements.org/hub/5751) hubs should only be made if they include at least 3 games.
 	- Homebrew Developer and [Hacker](https://retroachievements.org/hub/913) hubs should have at least 5 games.
 	- Some other hub types, like [Theme](https://retroachievements.org/hub/5699), [Setting](https://retroachievements.org/hub/29405), and [Protagonist](https://retroachievements.org/hub/5743), require a significantly higher number of games and will be made very sparingly.
+	- [Hacks](https://retroachievements.org/hub/5987) hubs can be made even if they only include 1 or 2 games. This is because they allow the game page to conveniently display "Hack of: Game" in the info section.
 - Take care not to create frivolous hubs - hub lists on game pages can already be too long as it is.
 
 ### Common Hubs
@@ -172,11 +216,10 @@ Hubs are used to categorize game pages in a variety of ways. Links to similar ga
 - [Language](https://retroachievements.org/hub/7885) hubs should be linked whenever applicable.
 - [Series](https://retroachievements.org/hub/3) hubs are commonly used whenever a game is part of a broader series.
 	- Bootleg/pirate games and fan games should not be added to the Series hub they're based on.
-- Hacks should be added to their respective [Hacks](https://retroachievements.org/hub/5987) hub, should one exist. This hub will automatically be displayed in the publisher field at the top of a game page.
-	- Hacks can also be added to a Series Hacks hub if one exists. Hacks hubs are intended to apply to one specific game, while Series Hacks hubs can collect different games in the same series. Note that Series Hacks hubs do not appear in the publisher field.
+- Hacks should be added to their respective [Hacks](https://retroachievements.org/hub/5987) hub. This hub type will automatically cause "Hack of: Game" to display in the info section.
+	- Hacks can also be added to a Series Hacks hub if one exists. Hacks hubs are intended to apply to one specific game, while Series Hacks hubs can collect different games in the same series.
 	- If a game doesn't have a Hacks hub, it should be added to [Uncategorized Hacks](https://retroachievements.org/hub/8018), even if it's in a Series Hacks hub.
 - Homebrews, demos, prototypes, and unlicensed games should always be added to [Central - Homebrew](https://retroachievements.org/hub/2469), [Central - Demo](https://retroachievements.org/hub/5901), [Central - Prototypes](https://retroachievements.org/hub/7824), or [Central - Unlicensed](https://retroachievements.org/hub/5751).
-	- Exceptions are made when an unlicensed game is in an unlicensed series hub, such as [Unlicensed - Mario](https://retroachievements.org/hub/29507). The Central hub shouldn't be redundantly added in these cases.
 - Subsets should always be added to a [Subsets](https://retroachievements.org/hub/18903) hub. Note that there are specialized hubs for subset types such as Bonus and Multi.
 	- Subsets should also inherit all hubs from their base game page.
 - Many other hubs exist - you can browse them [here](https://retroachievements.org/hubs).
@@ -198,7 +241,7 @@ Hubs are used to categorize game pages in a variety of ways. Links to similar ga
 
 ## Contributing Game Info
 
-Users may help submit game info, images, and hubs in the **Cleanup Requests forum**, one of the channels in our [Discord server](https://discord.gg/dq2E4hE).
+Users may help submit game info, images, and hubs in the **Cleanup Requests forum**, one of the channels in our [Discord server](https://discord.gg/dq2E4hE). A pinned thread in the forum gives guidelines on how to make submissions - those guidelines are more in-depth and take precedence over the information below if it becomes outdated.
 
 ### Tagging Your Posts
 
@@ -225,7 +268,7 @@ Users may help submit game info, images, and hubs in the **Cleanup Requests foru
 - Icons can only be submitted when a game doesn't already have one. If it does, you must use the [Icon Gauntlet](/guidelines/content/achievement-set-revisions#icon-gauntlet) instead.
 	- Exceptions can be made if the icon is a simple quality upgrade. But any kind of change in color or composition requires an Icon Gauntlet vote.
 - Remember that images should have the proper dimensions - 96x96 for icons, and whenever possible, the standard dimensions for a given system's screenshots, listed above.
-- Remember also that images need to be smaller than 1 MB in size.
+- Remember also that images need to be smaller than 1 MB in size for box art, or 4 MB for screenshots.
 
 ### Achievement Type
 


### PR DESCRIPTION
- Removed outdated information on FDS game titles
- Clarified that hacks of unlicensed or homebrew games can simply be tagged `~Hack~` instead of `~Unlicensed~ ~Hack~` or `~Homebrew~ ~Hack~`
- Clarified that sometimes unofficial game titles can be used as the canonical title if they're very well-known and used by other sources such as Wikipedia, like "Fire Emblem: The Blazing Blade"
- Removed outdated information on the publisher field for hacks
- Capitalized "Turn-Based RPG" since that change was made with the hub
- Screenshots can now be up to 4 MB
- Heavily updated the screenshot dimensions section to match with the new settings on the site
- New information that Hacks hubs can be made with only 1 or 2 games
- Removed outdated information on how to use the Unlicensed hub
- Added notice that the pinned thread in the site cleanup forum is more in-depth and takes precedence for guidelines on contributing