### PR TITLE
Split the old subset page into technical and design pages

### DIFF
--- a/docs/guidelines/content/subset_design.md
+++ b/docs/guidelines/content/subset_design.md
@@ -11,7 +11,7 @@ Here are golden rules of subset design:
 
 1. **Subsets should not take away from base sets**. As a general rule, a well balanced version of a challenge in a base set is preferable to an extreme version in a subset. Remember that base sets are the core and most important part of RA. They should never be watered down for the benefit of side content. Consistency across sets is of utmost importance to the player experience and subsets designed to include what is included in base sets for other games is unacceptable.
 
-2. **Subsets are sets, not random assortments of achievements left on the cutting room floor**. To design means to iterate, assess, ditch and improve. Not every idea ends up being published, and that's part of the process. Subsets are part of RA's offering and are public facing, not a window into a workshop with unfinished or unrefined projects. Throwing together ideas that were scrapped from a base set leads to sets that are incoherent or generally lack set identity.
+2. **Subsets are sets, not random assortments of achievements left on the cutting room floor**. Subsets must have coherent identities. To design means to iterate, assess, ditch and improve. Not every idea ends up being published, and that's part of the process. Subsets are part of RA's offering and are public facing, not a window into a workshop with unfinished or unrefined projects. Throwing together ideas that were scrapped from a base set leads to sets that are incoherent or generally lack set identity.
 
 3. **Not every game needs a subset**. Trying to force a subset into a game where it does not arise naturally often leads to poor sets that feel arbitrary. Like the design of base sets, subset design has to complement gameplay in a purposeful and compelling way.
 

--- a/docs/guidelines/content/subset_design.md
+++ b/docs/guidelines/content/subset_design.md
@@ -17,7 +17,7 @@ Here are golden rules of subset design:
 
 4. **Precedent should be taken with a grain of salt when it comes to subsets**. A challenge being interesting in one game *despite* going against conventional wisdom does not mean that it's reasonable elsewhere. This means that the same idea can be good in one context and bad in another, and that's ok.
 
-5. **Problematic base set achievements should be revised or demoted, not pushed to a subset.** It can be tempting to try and salvage a concept by pushing it to a subset, potentially extending or iterating on it. Revising an achievement so it is appropriate for the base set is almost always the address problems when the concept is interesting. Inclusion in a subset is not something that should be done in a rush as a half measure to avoid demotion; demote first, then consider if the idea fits into a subset that is complete and coherent.
+5. **Problematic base set achievements should be revised or demoted, not pushed to a subset.** It can be tempting to try and salvage a concept by pushing it to a subset, potentially extending or iterating on it. Revising an achievement so it is appropriate for the base set is almost always the best way to address problems when the concept is interesting. Inclusion in a subset is not something that should be done in a rush as a half measure to avoid demotion; demote first, then consider if the idea fits into a subset that is complete and coherent.
 
 The following are common subset archetypes:
 - [Multiplayer](#multiplayer)
@@ -40,7 +40,7 @@ For games where multiplayer is core to the experience, it is recommended to make
 
 Multiplayer subsets must be called `GameName [Subset - Multiplayer]`.
 
-Examples: https://retroachievements.org/game/814?set=7714 https://retroachievements.org/game/25451?set=9556
+Examples: [Kirby Super Star - Multiplayer](https://retroachievements.org/game/814?set=7714),  [Mario Party 5 - Multiplayer](https://retroachievements.org/game/25451?set=9556)
 ### Glitch Showcase
 
 Glitching can have unpredictable effects in a game's memory, which can result in unwanted behavior for some achievements, thus making them not suitable for a base set. However many glitches can add fun or interesting gameplay, effects, or just silly actions and may be worth highlighting outside of the base set.
@@ -49,7 +49,7 @@ When researching glitches, one should evaluate their feasibility. Glitches are o
 
 Glitch Showcase subsets must be called `GameName [Subset - Glitch Showcase]`.
 
-Examples: https://retroachievements.org/game/10210?set=8397 https://retroachievements.org/game/10154?set=33103
+Examples: [Banjo-Kazooie - Glitch Showcase](https://retroachievements.org/game/10210?set=8397),  [Paper Mario - Glitch Showcase](https://retroachievements.org/game/10154?set=33103)
 ### Excessive Grinds
 
 When challenges involve overly long grinds, be it due to low odds of obtaining certain items or simply because of the time involved, they can sometimes make for good subsets. Remember that these can be good ideas *despite* being overly long. You should always think about the experience of the player; what is motivating the player to complete the grind? Gaining access to a wide variety of things along the way is more enjoyable and varied than simply leveling anything one can think of to max level when there are no significant changes in the process.
@@ -58,7 +58,7 @@ Another common pitfall is removing content from the base set because it is cover
 
 When designing a grind subset, you have to evaluate the expected time it takes to master. The level of grouping as well as scoring have to reflect the time spent.
 
-Examples: https://retroachievements.org/game/788?set=32993 https://retroachievements.org/game/264?set=7250
+Examples: [Pokémon LeafGreen Version - Professor Oak Challenge](https://retroachievements.org/game/788?set=32993),  [EarthBound - Rare Drops](https://retroachievements.org/game/264?set=7250)
 
 ### Exhaustive Challenge Runs
 
@@ -66,7 +66,7 @@ A common subset structure is to have the most challenging 1-3 achievements in a 
 
 When designing this type of subset, make sure that the experience is significantly different between different characters. The series can become pointless if the same strategies can more or less be re-used for multiple characters.
 
-Examples: https://retroachievements.org/game/5853?set=35101 https://retroachievements.org/game/9602?set=37197
+Examples: [Pokémon Black Version 2 - Monotype Challenge](https://retroachievements.org/game/5853?set=35101),  [Super Smash Bros. Melee - Very Hard Runs](https://retroachievements.org/game/9602?set=37197)
 
 ### Brutal Full Game Runs
 
@@ -76,7 +76,7 @@ While frustration is expected in these types of subsets, it should come from the
 
 Strong full game run achievements are very difficult, but fair, and are not arbitrary goals. Challenges like speedruns, low level games or extremely high scores can be great, but conditions cannot be arbitrarily selected. Speedruns should be for going under community recognized barriers, or under thresholds only reachable using glitches, low level games should be at theoretical minimums, or justify why the targets have some leeway, and high scores should similarly either follow a community target or reach an actual maximum unfit for a base set. 
 
-Examples: https://retroachievements.org/game/1449?set=35581 https://retroachievements.org/game/1453?set=4345
+Examples: [Final Fantasy - Low Level Game](https://retroachievements.org/game/1449?set=35581),  [Zelda II: The Adventure of Link - Level-1 Runs](https://retroachievements.org/game/1453?set=4345)
 ### Community Recognized Challenges
 
 Community recognition is often indicative of good subset ideas. While these often fall in one of the categories above, being recognized by a community means that the concept was deemed interesting somewhere outside RA, making it a strong candidate.
@@ -85,19 +85,19 @@ Some challenges that are popular outside of RA sadly can be impossible to track 
 
 Consider requesting feedback from experts in the game's community. They often are the best people to assess the difficulty of challenges and are usually happy to help.
 
-Examples: https://retroachievements.org/game/7693?set=37503 https://retroachievements.org/game/10003?set=34377
+Examples: [Mario Kart: Double Dash!! - Hero](https://retroachievements.org/game/7693?set=37503),  [Super Mario 64 - A Button Challenge](https://retroachievements.org/game/10003?set=34377)
 
 ### RA Community Custom Content
 
 If a game has a feature that allows players to make their own content such as custom levels, then a subset featuring content made by the RA community can be a great idea. Organizing with the Event team can lead to fun community projects.
 
-Examples: https://retroachievements.org/game/8929?set=7769 https://retroachievements.org/game/2993?set=27843
+Examples: [Irritating Stick - IrRAtating Custom Courses](https://retroachievements.org/game/8929?set=7769),  [Tony Hawk's Underground - RAdical Custom Goals & Gaps](https://retroachievements.org/game/2993?set=27843)
 
 ### Expansions and Games Inside Games
 
 It is recommended to cover content from expansions, DLC, and unlocked games whenever it is reasonable to do so. When that content is either fundamentally different, very difficult to access, or too extensive to cover in the base set, a subset can be a good way to cover that content. These are for exceptional cases
 
-Examples: https://retroachievements.org/game/3154?set=21201 https://retroachievements.org/game/35305?set=38076 https://retroachievements.org/game/34685?set=37916
+Examples: [Metroid Prime - NES Metroid](https://retroachievements.org/game/3154?set=21201),  [Indiana Jones and the Staff of Kings - Fate of Atlantis](https://retroachievements.org/game/35305?set=38076),  [Guitar Hero: Warriors of Rock - DLC](https://retroachievements.org/game/34685?set=37916)
 ### Miscellaneous Extreme Challenges
 
 When there are series of challenges that are interesting, too extreme for the base set but not extensive enough to warrant a full subset individually, grouping them up to make a variety subset can be a good idea. 
@@ -106,15 +106,15 @@ One should approach the design of such a subset very carefully, and be ready to 
 
 Another risk is to lack research and understanding of the difficulty of the challenges. Thoroughly test the achievements with Hardcore in mind, and consider reaching out to experts of the game for feedback. Again, the goal is to avoid hodgepodge of arbitrary challenges that are simply not well balanced enough to be in a base set. Rebalancing the challenges so they are fit for the base set is often best.
 
-Examples: https://retroachievements.org/game/1447?set=3123 https://retroachievements.org/game/9049?set=9014
+Examples: [Contra - Bonus](https://retroachievements.org/game/1447?set=3123),  [Guitar Hero II - Expert Full Combo](https://retroachievements.org/game/9049?set=9014)
 
 ## Subset Patches
 
 In most cases, subsets are entirely accessible without any changes to the game. They are available through RetroAchievement's multiset feature, see [Subset Types and Multiset](link) for more information.
 
-In some situations, a patch can be made for quality of life improvements, or to enforce certain rules through multiple sessions. A typical example is Super Mario 64 - Lazy Lakitu, which keeps the fixed camera mode continuously activated.
+In some situations, a patch can be made for quality of life improvements, or to enforce certain rules through multiple sessions. A typical example is [Super Mario 64 - Lazy Lakitu](https://retroachievements.org/game/10003?set=8509), which keeps the fixed camera mode continuously activated.
 
-**Patches that modify the game in any way must be approved by Developer Compliance.** Changes that go beyond quality of life are rarely fit for subset but can be considered for ~Hack~ entries.  For these, make sure that you take the time to design a hack that stands on its own by providing a new experience. This should be considered carefully and ran by expert players whenever possible, especially when attempting to make the experience harder. This will help identifying exploits that you may have missed as well as assess the fairness of the extra challenge. Thorough testing the difficulty of such hacks is primordial; it should not be made on a whim. A good question to keep in mind is "Would this hack be interesting enough to interest players if RA didn't exist?"
+**Patches that modify the game in any way must be approved by Developer Compliance.** Changes that go beyond quality of life are rarely fit for subset but can be considered for `~Hack~` entries.  For these, make sure that you take the time to design a hack that stands on its own by providing a new experience. This should be considered carefully and ran by expert players whenever possible, especially when attempting to make the experience harder. This will help identifying exploits that you may have missed as well as assess the fairness of the extra challenge. Thorough testing the difficulty of such hacks is primordial; it should not be made on a whim. A good question to keep in mind is "Would this hack be interesting enough to interest players if RA didn't exist?"
 
 ## Approval and Claims
 

--- a/docs/guidelines/content/subset_design.md
+++ b/docs/guidelines/content/subset_design.md
@@ -106,6 +106,8 @@ One should approach the design of such a subset very carefully, and be ready to 
 
 Another risk is to lack research and understanding of the difficulty of the challenges. Thoroughly test the achievements with Hardcore in mind, and consider reaching out to experts of the game for feedback. Again, the goal is to avoid hodgepodge of arbitrary challenges that are simply not well balanced enough to be in a base set. Rebalancing the challenges so they are fit for the base set is often best.
 
+While older subsets like these were simply called "Bonus", new ones should instead use a more explicit name to avoid any confusion with the Bonus subset technical type. A thematic name is often best.
+
 Examples: [Contra - Bonus](https://retroachievements.org/game/1447?set=3123),  [Guitar Hero II - Expert Full Combo](https://retroachievements.org/game/9049?set=9014), [Metroid Prime 3: Corruption - Extra Corruption](https://retroachievements.org/game/34689?set=38075)
 
 ## Subset Patches
@@ -127,17 +129,17 @@ The following subset types are pre-approved for retail games:
 - Solo Class/Monotype Runs (Exhaustive Challenge Runs, or Brutal Full Game Run)
 - Professor Oak Challenges for official Pokémon main series releases (Excessive Grind)
 
-Every other subset must be approved before claiming. (section TBD with Design Team docs)
+Every other subset must be approved before claiming. This process can be initiated by opening a discussion thread in #design-feedback on Discord, or contacting [SetDesigners](https://retroachievements.org/user/SetDesigners), answering the following questions:
 
 - _Which archetype does this subset proposal fall under?_
-- _Why this is unfit for the base set?_
-- _Why this is appropriate despite being unfit for the base set?_
-- _How difficult are the achievements proposed? Explain in as much detail as possible :_
-- _Present a thorough set plan that explains what the set would look like :_
+- _Why is this unfit for the base set?_
+- _Why should this exist despite being unfit for the base set?_
+- _Can you explain your set plan in detail?_
 
-Please answer the above in a way that is understandable for someone that is not an expert of the game. If scores or times are involved, please provide a few explicit examples of what the set would require.
+Answer the above in a way that is understandable for someone that is not an expert of the game. If scores or times are involved, provide a few explicit examples of what the set would require.
 
-Moreover, adding a subset to a game is considered a revision of its base set. In addition to any required approval, a revision vote might be required before claiming as detailed below:
+## Revision Votes
+Finally, adding a subset to a game is considered a revision of its base set. In addition to any required approval, a revision vote might be required before claiming as detailed below:
 
 | Authorship¹            | Approval and Claiming Process                                                                                                                                                                                                                             |
 | :--------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/guidelines/content/subset_design.md
+++ b/docs/guidelines/content/subset_design.md
@@ -24,7 +24,7 @@ The following are common subset archetypes:
 - [Glitch Showcase](#glitch-showcase)
 - [Excessive Grinds](#excessive-grinds)
 - [Exhaustive Challenge Runs](#exhaustive-challenge-runs)
-- [Brutal Full Game Run](#brutal-full-game-run)
+- [Brutal Full Game Runs](#brutal-full-game-runs)
 - [Community Recognized Challenges](#community-recognized-challenges)
 - [RA Community Custom Content](#ra-community-custom-content)
 - [Expansions and Games Inside Games](#expansions-and-games-inside-games)
@@ -62,7 +62,7 @@ Examples: [Pokémon LeafGreen Version - Professor Oak Challenge](https://retroac
 
 ### Exhaustive Challenge Runs
 
-A common subset structure is to have the most challenging 1-3 achievements in a game with multiple characters allow choosing any character for the base set, and have a subset for doing it with every character. This increases player agency in the base set, doesn't take away from the base set since the challenge is still there, and make for very challenging subsets.
+For base sets, it is common to have the hardest achievements allow the use of any character or team. Adding a subset for doing these extreme challenges with every possible character can make for an interesting experience. This increases player agency in the base set, doesn't take away from the base set since the challenge is still there, and make for very challenging subsets.
 
 When designing this type of subset, make sure that the experience is significantly different between different characters. The series can become pointless if the same strategies can more or less be re-used for multiple characters.
 
@@ -95,9 +95,9 @@ Examples: [Irritating Stick - IrRAtating Custom Courses](https://retroachievemen
 
 ### Expansions and Games Inside Games
 
-It is recommended to cover content from expansions, DLC, and unlocked games whenever it is reasonable to do so. When that content is either fundamentally different, very difficult to access, or too extensive to cover in the base set, a subset can be a good way to cover that content. These are for exceptional cases
+It is recommended to cover content from expansions, DLC, and unlocked games whenever it is reasonable to do so. When that content is either fundamentally different, very difficult to access, or too extensive to cover in the base set, a subset can be a good way to cover that content. 
 
-Examples: [Metroid Prime - NES Metroid](https://retroachievements.org/game/3154?set=21201),  [Indiana Jones and the Staff of Kings - Fate of Atlantis](https://retroachievements.org/game/35305?set=38076),  [Guitar Hero: Warriors of Rock - DLC](https://retroachievements.org/game/34685?set=37916)
+Examples: [Indiana Jones and the Staff of Kings - Fate of Atlantis](https://retroachievements.org/game/35305?set=38076),  [Guitar Hero: Warriors of Rock - DLC](https://retroachievements.org/game/34685?set=37916)
 ### Miscellaneous Extreme Challenges
 
 When there are series of challenges that are interesting, too extreme for the base set but not extensive enough to warrant a full subset individually, grouping them up to make a variety subset can be a good idea. 
@@ -106,11 +106,11 @@ One should approach the design of such a subset very carefully, and be ready to 
 
 Another risk is to lack research and understanding of the difficulty of the challenges. Thoroughly test the achievements with Hardcore in mind, and consider reaching out to experts of the game for feedback. Again, the goal is to avoid hodgepodge of arbitrary challenges that are simply not well balanced enough to be in a base set. Rebalancing the challenges so they are fit for the base set is often best.
 
-Examples: [Contra - Bonus](https://retroachievements.org/game/1447?set=3123),  [Guitar Hero II - Expert Full Combo](https://retroachievements.org/game/9049?set=9014)
+Examples: [Contra - Bonus](https://retroachievements.org/game/1447?set=3123),  [Guitar Hero II - Expert Full Combo](https://retroachievements.org/game/9049?set=9014), [Metroid Prime 3: Corruption - Extra Corruption](https://retroachievements.org/game/34689?set=38075)
 
 ## Subset Patches
 
-In most cases, subsets are entirely accessible without any changes to the game. They are available through RetroAchievement's multiset feature, see [Subset Types and Multiset](link) for more information.
+In most cases, subsets are entirely accessible without any changes to the game. They are available through RetroAchievement's multiset feature, see [Subset Types and Multiset](/guidelines/content/subsets) for more information.
 
 In some situations, a patch can be made for quality of life improvements, or to enforce certain rules through multiple sessions. A typical example is [Super Mario 64 - Lazy Lakitu](https://retroachievements.org/game/10003?set=8509), which keeps the fixed camera mode continuously activated.
 
@@ -122,6 +122,7 @@ The following subset types are pre-approved for retail games:
 
 - Multiplayer Cooperative
 - Glitch Showcases
+- RA Community Custom Content
 - Low Level Game/No Leveling Runs (Brutal Full Game Run)
 - Solo Class/Monotype Runs (Exhaustive Challenge Runs, or Brutal Full Game Run)
 - Professor Oak Challenges for official Pokémon main series releases (Excessive Grind)
@@ -140,7 +141,7 @@ Moreover, adding a subset to a game is considered a revision of its base set. In
 
 | Authorship¹            | Approval and Claiming Process                                                                                                                                                                                                                             |
 | :--------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Author of the base set | • If all active authors of the set approve, does not require a plan and revision vote<br> • Considered a free claim ²                                                                                                                                     |
+| Author of the base set | • If all active authors of the set approve, does not require a revision vote<br> • Considered a free claim ²                                                                                                                                     |
 | No Core Set Authorship | • A set plan must be posted in the base set's forum topic and must go through standard revision voting<br> • Is **not** considered a free claim<br> • In the event that both a revision and subset plan are made for a set, both claims will count as one |
 
 ¹ In the case of multiple revision authors, use the most restrictive ruleset in the table. Example: If there is a subset collaboration and any subset author is not a core set author, use the `No Core Set Authorship` rules.

--- a/docs/guidelines/content/subset_design.md
+++ b/docs/guidelines/content/subset_design.md
@@ -1,0 +1,148 @@
+---
+title: Subset Design
+description: Learn about creating and managing subsets for RetroAchievements, including design guidelines as well as approval processes
+---
+
+Subsets are secondary sets attached to games that already have a base set. While RA shines through its complete sets that include challenges and make masteries satisfying, certain games are home to challenges that are poor fit for base sets yet have become of interest to the community.
+
+The design of these so-called subsets is particularly challenging. Challenges unfit for base sets are easy to come up with, simply disregarding good design practices or including unwelcome concepts will make sure of that. The challenging part is designing a subset that provides an interesting experience *despite* going against guidelines and conventional wisdom.
+
+Here are golden rules of subset design:
+
+1. **Subsets should not take away from base sets**. As a general rule, a well balanced version of a challenge in a base set is preferable to an extreme version in a subset. Remember that base sets are the core and most important part of RA. They should never be watered down for the benefit of side content. Consistency across sets is of utmost importance to the player experience and subsets designed to include what is included in base sets for other games is unacceptable.
+
+2. **Subsets are sets, not random assortments of achievements left on the cutting room floor**. To design means to iterate, assess, ditch and improve. Not every idea ends up being published, and that's part of the process. Subsets are part of RA's offering and are public facing, not a window into a workshop with unfinished or unrefined projects. Throwing together ideas that were scrapped from a base set leads to sets that are incoherent or generally lack set identity.
+
+3. **Not every game needs a subset**. Trying to force a subset into a game where it does not arise naturally often leads to poor sets that feel arbitrary. Like the design of base sets, subset design has to complement gameplay in a purposeful and compelling way.
+
+4. **Precedent should be taken with a grain of salt when it comes to subsets**. A challenge being interesting in one game *despite* going against conventional wisdom does not mean that it's reasonable elsewhere. This means that the same idea can be good in one context and bad in another, and that's ok.
+
+5. **Problematic base set achievements should be revised or demoted, not pushed to a subset.** It can be tempting to try and salvage a concept by pushing it to a subset, potentially extending or iterating on it. Revising an achievement so it is appropriate for the base set is almost always the address problems when the concept is interesting. Inclusion in a subset is not something that should be done in a rush as a half measure to avoid demotion; demote first, then consider if the idea fits into a subset that is complete and coherent.
+
+The following are common subset archetypes:
+- [Multiplayer](#multiplayer)
+- [Glitch Showcase](#glitch-showcase)
+- [Excessive Grinds](#excessive-grinds)
+- [Exhaustive Challenge Runs](#exhaustive-challenge-runs)
+- [Brutal Full Game Run](#brutal-full-game-run)
+- [Community Recognized Challenges](#community-recognized-challenges)
+- [RA Community Custom Content](#ra-community-custom-content)
+- [Expansions and Games Inside Games](#expansions-and-games-inside-games)
+- [Miscellaneous Extreme Challenges](#miscellaneous-extreme-challenges)
+
+Let's go over guidelines and common pitfalls when designing subsets of each archetype.
+
+### Multiplayer 
+
+Multiplayer Cooperative sets must require two or more players to be inputting controls. Achievements must require multiple players in order to be appropriate for this type of subset. It is not acceptable to be able to simply earn achievements with a single player while in a multiplayer mode.
+
+For games where multiplayer is core to the experience, it is recommended to make the base set compatible with multiplayer as much as possible. Taking multiplayer compatibility away from the base set because of the existence of a multiplayer subset is a bad practice. Challenges in this type of subsets should require all players to pull off something.
+
+Multiplayer subsets must be called `GameName [Subset - Multiplayer]`.
+
+Examples: https://retroachievements.org/game/814?set=7714 https://retroachievements.org/game/25451?set=9556
+### Glitch Showcase
+
+Glitching can have unpredictable effects in a game's memory, which can result in unwanted behavior for some achievements, thus making them not suitable for a base set. However many glitches can add fun or interesting gameplay, effects, or just silly actions and may be worth highlighting outside of the base set.
+
+When researching glitches, one should evaluate their feasibility. Glitches are often discovered using external tools, and if only a handful of people ever pulled it off in real time, it probably should not be included in a subset.
+
+Glitch Showcase subsets must be called `GameName [Subset - Glitch Showcase]`.
+
+Examples: https://retroachievements.org/game/10210?set=8397 https://retroachievements.org/game/10154?set=33103
+### Excessive Grinds
+
+When challenges involve overly long grinds, be it due to low odds of obtaining certain items or simply because of the time involved, they can sometimes make for good subsets. Remember that these can be good ideas *despite* being overly long. You should always think about the experience of the player; what is motivating the player to complete the grind? Gaining access to a wide variety of things along the way is more enjoyable and varied than simply leveling anything one can think of to max level when there are no significant changes in the process.
+
+Another common pitfall is removing content from the base set because it is covered in a grindy subset. The vast majority of in-game collections are fit for base sets, and when they aren't, it's often because they aren't interesting. 
+
+When designing a grind subset, you have to evaluate the expected time it takes to master. The level of grouping as well as scoring have to reflect the time spent.
+
+Examples: https://retroachievements.org/game/788?set=32993 https://retroachievements.org/game/264?set=7250
+
+### Exhaustive Challenge Runs
+
+A common subset structure is to have the most challenging 1-3 achievements in a game with multiple characters allow choosing any character for the base set, and have a subset for doing it with every character. This increases player agency in the base set, doesn't take away from the base set since the challenge is still there, and make for very challenging subsets.
+
+When designing this type of subset, make sure that the experience is significantly different between different characters. The series can become pointless if the same strategies can more or less be re-used for multiple characters.
+
+Examples: https://retroachievements.org/game/5853?set=35101 https://retroachievements.org/game/9602?set=37197
+
+### Brutal Full Game Runs
+
+Full game runs under brutal conditions can turn games into grueling challenges where players need dozens if not hundreds of attempts before succeeding.  While clearly unfit for base sets, this is a type of challenges that needs to be considered extensively before making into a subset. Such challenges are possible to create in almost any game, but they are very often pointless, unfair, or uninteresting. 
+
+While frustration is expected in these types of subsets, it should come from the player's own honest mistakes or lack of knowledge, not from something outside of their control. Even small amounts of randomness in long form challenges where small mistakes cause entire resets can turn what would be a good idea into something better left on the cutting room floor.
+
+Strong full game run achievements are very difficult, but fair, and are not arbitrary goals. Challenges like speedruns, low level games or extremely high scores can be great, but conditions cannot be arbitrarily selected. Speedruns should be for going under community recognized barriers, or under thresholds only reachable using glitches, low level games should be at theoretical minimums, or justify why the targets have some leeway, and high scores should similarly either follow a community target or reach an actual maximum unfit for a base set. 
+
+Examples: https://retroachievements.org/game/1449?set=35581 https://retroachievements.org/game/1453?set=4345
+### Community Recognized Challenges
+
+Community recognition is often indicative of good subset ideas. While these often fall in one of the categories above, being recognized by a community means that the concept was deemed interesting somewhere outside RA, making it a strong candidate.
+
+Some challenges that are popular outside of RA sadly can be impossible to track without patching the game, often turning the project into more of a hack than a subset.  
+
+Consider requesting feedback from experts in the game's community. They often are the best people to assess the difficulty of challenges and are usually happy to help.
+
+Examples: https://retroachievements.org/game/7693?set=37503 https://retroachievements.org/game/10003?set=34377
+
+### RA Community Custom Content
+
+If a game has a feature that allows players to make their own content such as custom levels, then a subset featuring content made by the RA community can be a great idea. Organizing with the Event team can lead to fun community projects.
+
+Examples: https://retroachievements.org/game/8929?set=7769 https://retroachievements.org/game/2993?set=27843
+
+### Expansions and Games Inside Games
+
+It is recommended to cover content from expansions, DLC, and unlocked games whenever it is reasonable to do so. When that content is either fundamentally different, very difficult to access, or too extensive to cover in the base set, a subset can be a good way to cover that content. These are for exceptional cases
+
+Examples: https://retroachievements.org/game/3154?set=21201 https://retroachievements.org/game/35305?set=38076 https://retroachievements.org/game/34685?set=37916
+### Miscellaneous Extreme Challenges
+
+When there are series of challenges that are interesting, too extreme for the base set but not extensive enough to warrant a full subset individually, grouping them up to make a variety subset can be a good idea. 
+
+One should approach the design of such a subset very carefully, and be ready to abandon their ideas when it does not pan out, even more than other types of subset. This is because this type of subset inherently has a weaker set identity, and can often be arbitrary. The best way to prevent this is to build the set around 1-4 series of challenges with strong and interesting themes; this helps making the set more coherent and memorable.
+
+Another risk is to lack research and understanding of the difficulty of the challenges. Thoroughly test the achievements with Hardcore in mind, and consider reaching out to experts of the game for feedback. Again, the goal is to avoid hodgepodge of arbitrary challenges that are simply not well balanced enough to be in a base set. Rebalancing the challenges so they are fit for the base set is often best.
+
+Examples: https://retroachievements.org/game/1447?set=3123 https://retroachievements.org/game/9049?set=9014
+
+## Subset Patches
+
+In most cases, subsets are entirely accessible without any changes to the game. They are available through RetroAchievement's multiset feature, see [Subset Types and Multiset](link) for more information.
+
+In some situations, a patch can be made for quality of life improvements, or to enforce certain rules through multiple sessions. A typical example is Super Mario 64 - Lazy Lakitu, which keeps the fixed camera mode continuously activated.
+
+**Patches that modify the game in any way must be approved by Developer Compliance.** Changes that go beyond quality of life are rarely fit for subset but can be considered for ~Hack~ entries.  For these, make sure that you take the time to design a hack that stands on its own by providing a new experience. This should be considered carefully and ran by expert players whenever possible, especially when attempting to make the experience harder. This will help identifying exploits that you may have missed as well as assess the fairness of the extra challenge. Thorough testing the difficulty of such hacks is primordial; it should not be made on a whim. A good question to keep in mind is "Would this hack be interesting enough to interest players if RA didn't exist?"
+
+## Approval and Claims
+
+The following subset types are pre-approved for retail games:
+
+- Multiplayer Cooperative
+- Glitch Showcases
+- Low Level Game/No Leveling Runs (Brutal Full Game Run)
+- Solo Class/Monotype Runs (Exhaustive Challenge Runs, or Brutal Full Game Run)
+- Professor Oak Challenges for official Pokémon main series releases (Excessive Grind)
+
+Every other subset must be approved before claiming. (section TBD with Design Team docs)
+
+- _Which archetype does this subset proposal fall under?_
+- _Why this is unfit for the base set?_
+- _Why this is appropriate despite being unfit for the base set?_
+- _How difficult are the achievements proposed? Explain in as much detail as possible :_
+- _Present a thorough set plan that explains what the set would look like :_
+
+Please answer the above in a way that is understandable for someone that is not an expert of the game. If scores or times are involved, please provide a few explicit examples of what the set would require.
+
+Moreover, adding a subset to a game is considered a revision of its base set. In addition to any required approval, a revision vote might be required before claiming as detailed below:
+
+| Authorship¹            | Approval and Claiming Process                                                                                                                                                                                                                             |
+| :--------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Author of the base set | • If all active authors of the set approve, does not require a plan and revision vote<br> • Considered a free claim ²                                                                                                                                     |
+| No Core Set Authorship | • A set plan must be posted in the base set's forum topic and must go through standard revision voting<br> • Is **not** considered a free claim<br> • In the event that both a revision and subset plan are made for a set, both claims will count as one |
+
+¹ In the case of multiple revision authors, use the most restrictive ruleset in the table. Example: If there is a subset collaboration and any subset author is not a core set author, use the `No Core Set Authorship` rules.
+
+² For now, an admin must be contacted via Discord or by [messaging RAdmin](https://retroachievements.org/user/RAdmin) to mark a claim as free. As a courtesy, please only request this if you actually need the claim slot or if you expect a long development period.

--- a/docs/guidelines/content/subsets.md
+++ b/docs/guidelines/content/subsets.md
@@ -3,7 +3,7 @@ title: Multiset and Subset Types
 description: Learn about subset types, multiset functionality and minimum requirements
 ---
 
-When browsing the [list of games](http://retroachievements.org/gameList.php), you will see that some games have a `[Subset]` tag in the title. Each of these contain achievements that for some reason or another, are not available in a game's base set. To learn more about the kind of challenges that are included in subsets, refer to the [Subset Design](link) docs.
+When browsing the [list of games](http://retroachievements.org/gameList.php), you will see that some games have a `[Subset]` tag in the title. Each of these contain achievements that for some reason or another, are not available in a game's base set. To learn more about the kind of challenges that are included in subsets, refer to the [Subset Design](guidelines/content/subset_design) docs.
 ## Set Types
 
 Subsets are now fully integrated into RetroAchievements through the multiset system. When you load a game, the server will automatically resolve which achievement sets to include based on the game hash you're using and your personal preferences. Developers link sets together, allowing you to play multiple sets (such as a base set and its bonus content) simultaneously without needing separate patches or playthroughs. 

--- a/docs/guidelines/content/subsets.md
+++ b/docs/guidelines/content/subsets.md
@@ -1,17 +1,20 @@
 ---
-title: Subsets
-description: Learn about creating and managing subsets for RetroAchievements, including types like Glitch Showcases, Challenge Runs, and DLC. This guide covers naming conventions, approval processes, and examples of different subset categories.
+title: Multiset and Subset Types
+description: Learn about subset types, multiset functionality and minimum requirements
 ---
 
-# Subsets
+When browsing the [list of games](http://retroachievements.org/gameList.php), you will see that some games have a `[Subset]` tag in the title. Each of these contain achievements that for some reason or another, are not available in a game's base set. To learn more about the kind of challenges that are included in subsets, refer to the [Subset Design](link) docs.
+## Set Types
 
-[[toc]]
+Subsets are now fully integrated into RetroAchievements through the multiset system. When you load a game, the server will automatically resolve which achievement sets to include based on the game hash you're using and your personal preferences. Developers link sets together, allowing you to play multiple sets (such as a base set and its bonus content) simultaneously without needing separate patches or playthroughs. 
 
-## What are Subsets?
+There are four technical set types that determine how sets relate to each other:
 
-When browsing the [list of games](http://retroachievements.org/gameList.php), you will see that some games have a `[Subset]` tag in the title. Each of these contain achievements that for some reason or another, are not available in a game's base set. Subsets are typically home to specific types of challenge runs.
-
-Subsets are now fully integrated into RetroAchievements through the multiset system. When you load a game, the server will automatically resolve which achievement sets to include based on the game hash you're using and your personal preferences. Developers link sets together, allowing you to play multiple sets (such as a base set and its bonus content) simultaneously without needing separate patches or playthroughs.
+- **Base**: The primary achievement set for a game. This is loaded by default and represents the main content.
+- **Bonus**: Additional achievements linked to a base set. When you load a base set, any associated bonus sets are also available based on your preferences.
+- **Challenge**: Like bonus, does not require a patched ROM but is opt-out by default, requiring you to opt-in to play. These are typically used when you play the game in a specific way, like low-level/single-member party runs in RPGs, beating a game without weapons, or doing as much as you can before a certain story event.
+- **Specialty**: These sets still require their own patched ROM, but also load the base set and any bonus sets automatically. These are typically used for alternate game modes or challenges that modify the game itself.
+- **Exclusive**: These sets load in isolation and are not compatible with any of the other game's sets.
 
 Multiset requires the latest version of your emulator:
 * RetroArch 1.22.1+
@@ -19,18 +22,6 @@ Multiset requires the latest version of your emulator:
 * DuckStation 0.1-10530+
 * Dolphin 2512-144+ (development build)
 * PPSSPP 1.19.3-1328+ (development build)
-
-## How Multiset Works
-
-### Set Types
-
-The multiset system uses four technical set types that determine how sets relate to each other:
-
-- **Base**: The primary achievement set for a game. This is loaded by default and represents the main content.
-- **Bonus**: Additional achievements linked to a base set. When you load a base set, any associated bonus sets are also available based on your preferences.
-- **Challenge**: Like bonus, does not require a patched ROM but is opt-out by default, requiring you to opt-in to play. These are typically used when you play the game in a specific way, like low-level/single-member party runs in RPGs, beating a game without weapons, or doing as much as you can before a certain story event.
-- **Specialty**: These sets still require their own patched ROM, but also load the base set and any bonus sets automatically. These are typically used for alternate game modes or challenges that modify the game itself.
-- **Exclusive**: These sets load in isolation and are not compatible with any of the other game's sets.
 
 ### User Preferences
 
@@ -42,129 +33,3 @@ You can control which subsets you want to play:
 ### Hash Compatibility
 
 Some achievement sets may be incompatible with certain game hashes (ROM versions, patches, etc). The server will automatically exclude incompatible sets from your emulator session. If you're testing hash compatibility, you may have special access to view sets that are normally hidden for incompatible hashes.
-
-## A Reminder
-
-Challenge achievements are base set content by default. Challenges only become appropriate for subsets when they are of an extreme nature that is far beyond what a typical challenge might be such as a full game damageless challenge. Subsets should not be used as a dumping ground for challenges that for whatever reason are not perfect fits into the base set.
-
-## Types of Subsets
-
-The categories below describe the _content type_ of subsets. When creating a subset, you'll also need to choose the appropriate _technical subset type_ (Bonus, Specialty, or Exclusive) based on how the subset should interact with the base set:
-
-- Use **Bonus** for most subsets that can be played alongside the base set without conflicts.
-- Use **Specialty** for challenge runs or modes that benefit from their own Rich Presence script but still work alongside base set achievements.
-- Use **Exclusive** for subsets that fundamentally change gameplay in ways that would altogether conflict with base set achievements (eg: completely incompatible memory).
-
-### Challenge Runs
-
-While many base sets include plenty of challenges, developers have the option to add challenges that last the duration of a game's playthrough to a Subset. These are typically self-imposed challenges that go against how a game is normally played. Examples:
-
-- [Chrono Trigger - No Level Up](https://retroachievements.org/game/9966) requires players to complete the game without ever leveling up their characters.
-- [EarthBound - Rare Drops](https://retroachievements.org/game/18280) requires players to obtain all the rare drops from enemies.
-- [Final Fantasy - Solo Class](https://retroachievements.org/game/17996) requires players to complete the game using only one character class, but they need to do it with every class to master the set.
-- [Super Mario Bros. - 5-Minute Speedrun](https://retroachievements.org/game/23910) requires players to complete the game in under a widely recognized threshold that is considered a significant accomplishment by the speedrunning community.
-- [Pokemon - Professor Oak Challenge](https://retroachievements.org/searchresults.php?s=Professor+Oak+Challenge) There are several of these so far! This challenge requires players to catch and/or evolve every Pokemon possible between major story points in the game.
-- [Trails in the Sky FC - NG Nightmare](https://retroachievements.org/game/11115) requires players to obtain 100% completion in a single, NG (New Game) playthrough on the Nightmare difficulty setting, as opposed to doing it on NG+ with carryovers.
-
-### Extreme or Brutal Challenges
-
-If it's generally voiced that a challenge is **too difficult**, it's a good candidate for a subset. However, just because the achievement(s) are possible to code does not mean they are possible to obtain; therefore, the achievement must still be obtainable. How difficult is too difficult? Something that few players of a set would be able to accomplish. If you expect under a 1% earn rate, it is probably extreme. If it feels unreasonable to require anyone to do an achievement, it is probably brutal.
-
-- A good example of a single achievement that could be considered extreme or brutal is the infamous [Mr. Perfect from Mega Man (NES)](https://retroachievements.org/achievement/53290), which requires the player to complete the _entire_ game without taking damage.
-- A good example of a full subset is [Ninja Gaiden | Shadow Warriors (NES) [Subset - Full Game Damageless]](https://retroachievements.org/game/25303).
-- Does not have to be named Brutal Challenge, but that subset type should be referenced in subset plan/any subset vote. If there are any doubts about whether challenges fall into this category, contact Developer Compliance for a quick judgement.
-
-### Multiplayer Cooperative Sets
-
-If an achievement _requires_ input from more than one player in order to unlock it, then it cannot be in the base set. Multiplayer Cooperative sets must require two or more players to be inputting controls. Achievements must require multiple players in order to be appropriate for this type of subset. It is not acceptable to be able to simply earn achievements with a single player while in a multiplayer mode.
-
-If the base game title is long, this subset type may be shortened. If a shortened name is required, the following prioritized list shall be used to find an option that fits: "Multiplayer Co-op," "Multi Co-op," or "Co-op".
-
-### DLC and Expansions
-
-Not very common, but will become more common as our console support expands. Achievements in these sets are exclusive to a game's downloadable content or expansion pack(s). Examples:
-
-- [Arc the Lad 2 - Arc Arena: Monster Tournament](https://retroachievements.org/game/17001) was released as a bonus disc in the Arc the Lad Collection, this requires save data from Arc the Lad 2 in order to play.
-- [F-Zero X - Expansion Kit](https://retroachievements.org/game/10962) - achievements are for content exclusive to the 64DD expansion of the game.
-- [Return Fire - Maps o' Death](https://retroachievements.org/game/16851) is a separate release that provides additional maps to the game. It requires save data from the original game in order to play.
-
-### Regional Differences
-
-If a regional variant of a game does not have enough differences to warrant a "full" set, but you don't want to include it with the base set due to interference with base challenges, a subset may be an option to showcase the differences.
-
-### User-Generated Content
-
-If a game has a feature that allows players to make their own content such as custom levels, then a subset would be an acceptable place to include said content. Examples:
-
-- [Irritating Stick - IrRAtating Custom Courses](https://retroachievements.org/game/20084) features custom stages made by various RA community members.
-- [Tony Hawk's Underground - RAdical Custom Goals/Gaps](https://retroachievements.org/game/20476) features custom goals and gaps made by various RA community members.
-
-### Grind Sessions
-
-If achievements involve overly long and frustrating grinds that have no meaningful purpose, they're better suited for subsets. These include leveling characters to the maximum level, maxing out stats, performing a task an absurd amount of times, etc. when none of those things award the player. A good grind session subset will have a strong, cohesive theme.
-
-- Please note that a grind does not automatically mean it's unsuitable for a base set: A good example of something grindy that awards the player, thus making it suitable for a base set, is [One of a Kind from Final Fantasy IV (SNES)](https://retroachievements.org/achievement/108720), which requires a highly RNG-reliant grind for an item to trade for said armor.
-
-### Glitch Showcases
-
-Glitching can have unpredictable effects in a game's memory, which can result in unwanted behavior for some achievements, thus making them not suitable for a base set. However many glitches can add fun or interesting gameplay, effects, or just silly actions and may be worth highlighting outside of the base set. Some examples of this are [Replica from Final Fantasy VII (PlayStation)](https://retroachievements.org/achievement/83776), [Rare Candy Addiction from Pokemon - Red and Blue Versions (Game Boy)](https://retroachievements.org/achievement/57643) and [Lock-Off the Lock-On from Sonic 3 & Knuckles (Genesis)](https://retroachievements.org/achievement/228498).
-
-### Checkpoint Challenges
-
-A subset where you have to collect or perform a lengthy grind prior each checkpoints, where checkpoints are clear and distributed throughout the game. Such subsets should not be heavily front-loaded, meaning that if most of the achievements are to be done before the first checkpoint, it is likely a poor subset candidate. A good example is most main game Pokemon Professor Oak Challenge subsets or [Zelda II: The Adventure of Link - Level-1 Runs](https://retroachievements.org/game/10311).
-
-### Perma-Death Challenges
-
-Restrictive challenges where player units or equivalent must never be used again if the die, expire, or otherwise lose in some way during play. (Examples: Pokemon Nuzlocke challenges or Strategy RPGs where perma-death isn't already a characteristic of the game). Note: These challenges may need support within the game or hack to be possible with the current toolkit.
-
-### Bonus
-
-A bonus set is a set with a variety of achievements that do not fit into the base set of a game for various reasons. These may be extremely difficult challenges that go beyond what is welcome, painful grinds that serve no particular purpose beyond getting stronger or collecting everything, a showcase of glitches, or many other kinds of things that wouldn't be considered good achievements for the base set.
-
-- Bonus sets should **not** be named `[Subset - Bonus]`. Instead, choose a name that fits thematically with the game to which this subset belongs.
-- A good example of the variety pack nature of a bonus set is the Suikoden Bonus Set, which contains various challenge runs, rare drops, and extreme challenges within a single subset.
-
-::: warning TIP
-Choose a name that fits thematically with the game.
-:::
-
-## Naming Scheme
-
-To prevent players from getting confused, there is a specific naming scheme required for all Subsets:
-
-- **Multiplayer Cooperative Sets**: Must have `[Subset - Multiplayer Cooperative]` following the base game title. For example: `Contra [Subset - Multiplayer Cooperative]`.
-- **Challenge Runs**: Must have `[Subset - Challenge Name/Type]` following the base game title. For example: `Chrono Trigger [Subset - No Level Up]` and `Pocket Monsters Midori [Subset - Monotype Challenge]`.
-- **DLC and Expansions**: Must have `[Subset - DLC/Expansion Name` following the base game title. For example: `Return Fire - [Subset - Maps o' Death]` and `F-Zero X [Subset - Expansion Kit]`.
-- **User-Generated Content**: While not actually required, including `RA` in the subset title has been a fun way to name the content.
-- **Bonus Sets**: Must have `[Subset - Bonus]` folowing the base game title. For example: `Castlevania - [Subset - Bonus]` and `Darkwing Duck - [Subset - Bonus]`
-
-## Approval and Claims
-
-The following subset types are pre-approved:
-
-- Multiplayer Cooperative
-- Glitch Showcases
-- User-Generated Content
-- Challenge Run: Low Level Game/No Leveling Runs
-- Challenge Run: Solo Class/Monotype Runs
-- Challenge Run: Professor Oak Challenges for official Pokemon main series releases
-
-Other types of subsets, including Bonus which was previously pre-approved, must be approved by Developer Compliance before claiming. To request approval, send a site message [here](https://retroachievements.org/createmessage.php?t=DevCompliance), detailing your proposal by addressing the points below.
-
-- _Explain why this is unfit for the base set:_
-- _Explain why this is appropriate despite being unfit for the base set :_
-- _How difficult are the achievements proposed? Explain in as much detail as possible :_
-- _Present a thorough set plan that explains what the set would look like :_
-
-Please answer the above in a way that is understandable for someone that is not an expert of the game. If scores or times are involved, please provide a few explicit examples of what the set would require.
-
-Moreover, adding a subset to a game is considered a revision of its base set. This means that after getting approval from [Developer Compliance](https://retroachievements.org/createmessage.php?t=DevCompliance), a revision vote might be required before claiming as detailed below:
-
-|Authorship¹|Approval and Claiming Process|
-|:--|:--|
-|Author of the base set|• If all active authors of the set approve, does not require a plan and revision vote<br> • Considered a free claim ²
-|No Core Set Authorship|• A set plan must be posted in the base set's forum topic and must go through standard revision voting<br> • Is **not** considered a free claim<br> • In the event that both a revision and subset plan are made for a set, both claims will count as one
-
-¹ In the case of multiple revision authors, use the most restrictive ruleset in the table. Example: If there is a subset collaboration and any subset author is not a core set author, use the `No Core Set Authorship` rules.
-
-² For now, an admin must be contacted via Discord or by [messaging RAdmin](https://retroachievements.org/user/RAdmin) to mark a claim as free. As a courtesy, please only request this if you actually need the claim slot or if you expect a long development period.


### PR DESCRIPTION
Reorganizing and writing new guidelines for subset design. 
Introduction of subset archetypes as a framework for approval.
Removal of pre-approved subsets for non-retail games.
Change the approval process to refer to the set design team.