### PR TITLE
Clarify rule 2 with an additional example

### DIFF
--- a/docs/guidelines/users/code-of-conduct.md
+++ b/docs/guidelines/users/code-of-conduct.md
@@ -45,6 +45,7 @@ If the [short version](#short-version) is not clear enough for you, here's a det
 #### Unacceptable social behavior
 
 - Asking for or posting links to sites where others could download copyrighted material.
+- Discussing methods for downloading copyrighted material, or alluding to specific methods or sites.
 - Spamming messages or attempting to vandalize Discord or the website by any means.
 - Advertising products, services, or other Discord servers without approval.
 - Bigotry: This includes racism, sexism, elitism; intolerance regarding others' nationality, religion, sexual orientation, political beliefs, etc.


### PR DESCRIPTION
This is a very minor change that adds an additional example to the list of unacceptable social behavior in the user code of conduct, specifically covering users who try to hint towards breaking the rule without explicitly mentioning sites.