### PR TITLE
Add clarity to icon gauntlet contact guidelines.

### DIFF
--- a/docs/guidelines/content/achievement-set-revisions.md
+++ b/docs/guidelines/content/achievement-set-revisions.md
@@ -149,6 +149,8 @@ Anyone wanting to rescore a set needs to:
 2. **Contact** each active author of the set. They may have valuable insight into the chosen scores. You do not need to wait for a response.
 
 - Some authors opt out of requiring contact. Check the [Public Opt-Out Sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRRSNI9R-ezC0ma7x2BoU2JiZgMu26iht-sIPc56otfJa2sd_8QQCO-V4JXbfsfSUbrl54wib68-Pjp/pubhtml?gid=1195161231&single=true). If the author is listed as opting out of this revision type, they do not need to be contacted. To update your own Opt-Out information, use [this form](https://forms.gle/mgzv7RHbJEPCrxc77).
+- When contacting, be clear that this contact is for an icon gauntlet.
+- When contacting, always ask if the author would like to be pinged when the vote starts. This ensures the author knows this is an option.
 
 3. **Post the plan** in the game's forum topic.
 


### PR DESCRIPTION
Had a gauntlet contact that seemed like it was a normal badge opinion contact. Wasn't pinged at vote.  Realized that the rules weren't really giving the proper standards for how contact should be managed.

Figure that most devs don't know that as-written, they'd have to request a ping at vote start (for cases where they need to weigh in on the badges in #gauntlet-discussion). This includes me, who wrote the rules draft in the first place.