### PR TITLE
feat: improve title and description in embeds

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -3,6 +3,7 @@ import { type HeadConfig, defineConfig } from "vitepress";
 export const shared = defineConfig({
   // Metadata
   title: "RetroAchievements",
+  titleTemplate: ":title | RetroAchievements Docs",
 
   // SEO
   head: getHeadTags(),
@@ -45,12 +46,20 @@ export const shared = defineConfig({
       },
     ],
   },
+
+  transformHead: (context) => {
+    const tags: HeadConfig[] = [
+      ["meta", { name: "twitter:title", content: context.title }],
+      ["meta", { name: "twitter:description", content: context.description }],
+    ];
+
+    return tags;
+  }
 });
 
 function getHeadTags(): HeadConfig[] {
   const tags: HeadConfig[] = [
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
-    ["meta", { name: "twitter:title", content: "RetroAchievements Docs" }],
     ["meta", { name: "twitter:site", content: "@RetroCheevos" }],
   ];
 


### PR DESCRIPTION
Currently, sending a docs link on Discord just always returns RetroAchievement Docs with no description or title or anything.

<img width="1188" height="174" alt="CleanShot 2026-06-22 at 16 58 04@2x" src="https://github.com/user-attachments/assets/cbbb95ff-ee95-411c-827f-7bfe5930d8fe" />

Now, it will return the full title and description.

<img width="942" height="288" alt="CleanShot 2026-06-22 at 16 58 31@2x" src="https://github.com/user-attachments/assets/4ca63f55-6819-4e9e-a534-eae8eb9b7399" />

A titleTemplate was added, meaning `| RetroAchievements Docs` is added to titles.

<img width="584" height="156" alt="CleanShot 2026-06-22 at 17 00 34@2x" src="https://github.com/user-attachments/assets/38446ebc-42d9-49dd-a371-e2784698dd90" />


The description pulls from the `description:` in the front-matter.