### PR TITLE
Update PS2 emulator

### DIFF
--- a/docs/general/emulator-support-and-issues.md
+++ b/docs/general/emulator-support-and-issues.md
@@ -350,8 +350,8 @@ Limited microphone support.
 
 | Name                                                                     | Type                | Notes |
 | :----------------------------------------------------------------------- | :------------------ | :---- |
+| **[ARMSX2](https://armsx2.net/)**                                        | Standalone emulator |       |
 | **[PCSX2](https://pcsx2.net/)**                                          | Standalone emulator |       |
-| **[NetherSX2](https://github.com/Trixarian/NetherSX2-classic/releases)** | Standalone emulator |       |
 | **[XBSX2](https://github.com/XboxEmulationHub/XBSX2/releases)**          | Standalone emulator |       |
 
 ### PlayStation Portable


### PR DESCRIPTION
NetherSX2 is no longer hardcore verified in favor of ARMSX2. See https://retroachievements.org/forums/topic/36517 and https://retroachievements.org/forums/topic/36402