### PR TITLE
Fix space + typo

### DIFF
--- a/docs/developer-docs/rich-presence.md
+++ b/docs/developer-docs/rich-presence.md
@@ -201,9 +201,9 @@ It is built by replacing any macros in the display string with text from a Looku
 
 This means use the Lookup or Format that's called `Powerup`, and give it whatever 8-bit value is in the address 0x756. After converting, put the result in between "Using " and "!".
 
-**NOTE**: Lookup/Format names are case sensitive and must exactly match the usage in the Display string: `@test(0x1234)` will not find `Format:Test`
+**NOTE**: Lookup/Format names are case-sensitive and must exactly match the usage in the Display string: `@test(0x1234)` will not find `Format:Test`
 
-**NOTE**: Lookup/Format definitions cannot contain spaces before or after the name. `@test(0x1234)` will not find `Format:test   ` or `Format:   test`
+**NOTE**: Lookup/Format definitions cannot contain spaces before or after the name. `@test(0x1234)` will not find `Format:test `&nbsp;or `Format: test`
 
 ### Example Lookup Breakdown
 


### PR DESCRIPTION
There was a missing space before:

<img width="972" height="112" alt="Screenshot from 2026-07-20 21-04-17" src="https://github.com/user-attachments/assets/a12b211b-c16e-4840-829b-3d2dab04cdde" />

While fixing this I cleaned up some additional whitespace (which won't be rendered anyway), and a typo ("case-sensitive").