### PR TITLE
update unsupported DS/DSi cores

### DIFF
--- a/docs/developer-docs/unsupported-emulators-and-cores.md
+++ b/docs/developer-docs/unsupported-emulators-and-cores.md
@@ -150,12 +150,12 @@ This is a list of emulators and cores that have either been confirmed to not wor
 | Name                       | Type          | Status  | Notes                               |
 | :------------------------- | :------------ | :-----: | :---------------------------------- |
 | **DeSmuME 2015**           | libretro core | ❌      | |
-| **melonDS 2021**           | libretro core | ❓       | |
 
 ## Nintendo DSi
 
 | Name                       | Type          | Status  | Notes                               |
 | :------------------------- | :------------ | :-----: | :---------------------------------- |
+| **DeSmuME 2015**           | libretro core | ❌ | |
 | **DeSmuME**                | libretro core | ❌ | |
 | **melonDS**                | libretro core | ❌ | |
 


### PR DESCRIPTION
The old melonDS core is supported and already listed in the [supported section](https://docs.retroachievements.org/general/emulator-support-and-issues.html#nintendo-ds).
I also added DeSmuME 2015 to the DSi section since it's a different core that is unsupported as well.