### PR TITLE
DevJam - Add DevJam XI

### DIFF
--- a/docs/developer-docs/devjam.md
+++ b/docs/developer-docs/devjam.md
@@ -65,13 +65,13 @@ Check the links here for console-specific guidelines and info:
 |   08   | 2025-07-01 - 2025-09-30 |                    [MSX](/developer-docs/devjam/8-msx)                     |           26           |      79       |
 |   09   | 2026-02-01 - 2026-04-30 |               [Catch-Up](/developer-docs/devjam/9-catch-up)                |           ??           |      ??       |
 |   10   | 2026-05-01 - 2026-07-31 | [Master System/Game Gear](/developer-docs/devjam/10-mastersystem-gamegear) |           ??           |      ??       |
+|   11   | 2026-08-01 - 2026-10-31 |           [Famicom Disk System](/developer-docs/devjam/10-fds)             |           ??           |      ??       |
 
 ## Planned DevJams
 
 Solo Console DevJams:
 
 - 3DO
-- Famicom Disk System
 - Nintendo DS
 
 Multi-Console DevJams:

--- a/docs/developer-docs/devjam.md
+++ b/docs/developer-docs/devjam.md
@@ -63,9 +63,9 @@ Check the links here for console-specific guidelines and info:
 |   06   | 2024-12-01 - 2025-03-16 |                [Apple II](/developer-docs/devjam/6-appleii)                |           20           |      40       |
 |   07   | 2025-04-01 - 2025-06-30 |             [Sega CD/32X](/developer-docs/devjam/7-segacd-32x)             |           27           |      40       |
 |   08   | 2025-07-01 - 2025-09-30 |                    [MSX](/developer-docs/devjam/8-msx)                     |           26           |      79       |
-|   09   | 2026-02-01 - 2026-04-30 |               [Catch-Up](/developer-docs/devjam/9-catch-up)                |           ??           |      ??       |
-|   10   | 2026-05-01 - 2026-07-31 | [Master System/Game Gear](/developer-docs/devjam/10-mastersystem-gamegear) |           ??           |      ??       |
-|   11   | 2026-08-01 - 2026-10-31 |           [Famicom Disk System](/developer-docs/devjam/10-fds)             |           ??           |      ??       |
+|   09   | 2026-02-01 - 2026-04-30 |               [Catch-Up](/developer-docs/devjam/9-catch-up)                |           18           |      40       |
+|   10   | 2026-05-01 - 2026-07-31 | [Master System/Game Gear](/developer-docs/devjam/10-mastersystem-gamegear) |           36           |      76       |
+|   11   | 2026-08-01 - 2026-10-31 |           [Famicom Disk System](/developer-docs/devjam/11-fds)             |           ??           |      ??       |
 
 ## Planned DevJams
 
@@ -82,7 +82,6 @@ Multi-Console DevJams:
 
 End of the Line for Console-Specific DevJams:
 
-- "Bottom of the Barrel" (Pokemon Mini, Virtual Boy, Magnavox Odyssey2, PC-FX)
 - "The Magnificent Seven" (Mega Drive, Nintendo 64, SNES, Game Boy, Game Boy Advance, Game Boy Color, NES)
 
 ## See Also

--- a/docs/developer-docs/devjam/11-fds.md
+++ b/docs/developer-docs/devjam/11-fds.md
@@ -28,9 +28,10 @@ This table details earnable points for the Master System/Game Gear DevJam:
 While the main goal is to promote a bunch of a sets, there are secondary goals that we can work on as a group. If a goal is met, bonus points will be applied _to those who helped reach it_. Goals that are focused on getting the number of sets to a certain number will grant bonus points to everyone who does a set, even after that goal is met. The Famicom Disk System goals are:
 
 - Top 10 requested games
-- All Nintendo developed games
+- All games developed by Nintendo
 - All games released in 1991 and 1992
-- Reach a total of 80 and 120 sets
+- Reach a total of 80 sets
+- Reach a total of 120 sets
 
 You can see the list of games and progress of each goal [here](https://docs.google.com/spreadsheets/d/1EBMW7nO95wvbsOAIfgm2XFnCCez2a14jRfYAnt-uqvo/edit?gid=1251711278#gid=1251711278).
 

--- a/docs/developer-docs/devjam/11-fds.md
+++ b/docs/developer-docs/devjam/11-fds.md
@@ -1,0 +1,50 @@
+# DevJam XI (Famicom Disk System)
+
+[[toc]]
+
+## Time and Duration
+
+- Start Date: 2026-08-01
+- Launch Date: 2026-10-31
+
+## Point System
+
+Max Earnable Points: 6
+
+This table details earnable points for the Master System/Game Gear DevJam:
+
+| Points |                   Set Submission                               |
+| :----: | :------------------------------------------------------------: |
+|   3    |                Licensed Games                                  |
+|   2    |                Homebrews/Hacks                                 |
+|   2    |                Prototypes/Unlicensed                           |
+|   1    |                Subsets                                         |
+|   2    |                Collaborations                                  |
+|   2    |                Late Submissions (Licensed Games)               |
+|   1    |                Late Submissions (Others)                       |
+
+## Quarterly Goals
+
+While the main goal is to promote a bunch of a sets, there are secondary goals that we can work on as a group. If a goal is met, bonus points will be applied _to those who helped reach it_. Goals that are focused on getting the number of sets to a certain number will grant bonus points to everyone who does a set, even after that goal is met. The Famicom Disk System goals are:
+
+- Top 10 requested games
+- All Nintendo developed games
+- All games released in 1991 and 1992
+- Reach a total of 70 and 100 sets
+
+You can see the list of games and progress of each goal [here](https://docs.google.com/spreadsheets/d/1EBMW7nO95wvbsOAIfgm2XFnCCez2a14jRfYAnt-uqvo/edit?gid=420135808#gid=420135808).
+
+## Stats
+
+_as of 2026-08-01 (start date)_
+
+- Current number of sets: 36 (1 hack, 1 prototype, 2 unlicensed)
+- Current number of achievements: 1,254
+- Current number of leaderboards: 225
+
+## See Also
+
+- [Main DevJam Page](/developer-docs/devjam)
+- [DevJam Vol. 1 Event Entry](https://retroachievements.org/game/20000)
+- [DevJam Vol. 2 Event Entry](https://retroachievements.org/game/30000)
+- [DevJam Forum Topic](https://retroachievements.org/viewtopic.php?t=22368)

--- a/docs/developer-docs/devjam/11-fds.md
+++ b/docs/developer-docs/devjam/11-fds.md
@@ -30,9 +30,9 @@ While the main goal is to promote a bunch of a sets, there are secondary goals t
 - Top 10 requested games
 - All Nintendo developed games
 - All games released in 1991 and 1992
-- Reach a total of 70 and 100 sets
+- Reach a total of 80 and 120 sets
 
-You can see the list of games and progress of each goal [here](https://docs.google.com/spreadsheets/d/1EBMW7nO95wvbsOAIfgm2XFnCCez2a14jRfYAnt-uqvo/edit?gid=420135808#gid=420135808).
+You can see the list of games and progress of each goal [here](https://docs.google.com/spreadsheets/d/1EBMW7nO95wvbsOAIfgm2XFnCCez2a14jRfYAnt-uqvo/edit?gid=1251711278#gid=1251711278).
 
 ## Stats
 

--- a/docs/developer-docs/devjam/11-fds.md
+++ b/docs/developer-docs/devjam/11-fds.md
@@ -11,7 +11,7 @@
 
 Max Earnable Points: 6
 
-This table details earnable points for the Master System/Game Gear DevJam:
+This table details earnable points for the Famicom Disk System DevJam:
 
 | Points |                   Set Submission                               |
 | :----: | :------------------------------------------------------------: |


### PR DESCRIPTION
Add page for DevJam XI. Update main DevJam page with stats for previous jams, add link to DevJam XI, and update list of planned jams.